### PR TITLE
feat(lyrics-plus): add `lrclib` as a provider

### DIFF
--- a/CustomApps/lyrics-plus/ProviderLRCLIB.js
+++ b/CustomApps/lyrics-plus/ProviderLRCLIB.js
@@ -36,7 +36,7 @@ const ProviderLRCLIB = (() => {
 
 		if (!unsyncedLyrics) return null;
 
-		return unsyncedLyrics.split("\n").map(text => ({ text }));
+		return Utils.parseLocalLyrics(syncedLyrics).unsynced;
 	}
 
 	function getSynced(body) {

--- a/CustomApps/lyrics-plus/ProviderLRCLIB.js
+++ b/CustomApps/lyrics-plus/ProviderLRCLIB.js
@@ -1,0 +1,53 @@
+const ProviderLRCLIB = (() => {
+	async function findLyrics(info) {
+		const baseURL = "https://lrclib.net/api/get";
+		const durr = info.duration / 1000;
+		const params = {
+			track_name: info.title,
+			artist_name: info.artist,
+			album_name: info.album,
+			duration: durr
+		};
+
+		const finalURL = `${baseURL}?${Object.keys(params)
+			.map(key => `${key}=${encodeURIComponent(params[key])}`)
+			.join("&")}`;
+
+		const body = await fetch(finalURL, {
+			headers: {
+				"user-agent": `spicetify v${Spicetify.Config.version} (https://github.com/spicetify/cli)`
+			}
+		});
+
+		if (body.status !== 200) {
+			return {
+				error: "Request error: Track wasn't found",
+				uri: info.uri
+			};
+		}
+
+		return await body.json();
+	}
+
+	function getUnsynced(body) {
+		const unsyncedLyrics = body?.plainLyrics;
+		const isInstrumental = body.instrumental;
+		if (isInstrumental) return [{ text: "♪ Instrumental ♪" }];
+
+		if (!unsyncedLyrics) return null;
+
+		return unsyncedLyrics.split("\n").map(text => ({ text }));
+	}
+
+	function getSynced(body) {
+		const syncedLyrics = body?.syncedLyrics;
+		const isInstrumental = body.instrumental;
+		if (isInstrumental) return [{ text: "♪ Instrumental ♪" }];
+
+		if (!syncedLyrics) return null;
+
+		return Utils.parseLocalLyrics(syncedLyrics).synced;
+	}
+
+	return { findLyrics, getSynced, getUnsynced };
+})();

--- a/CustomApps/lyrics-plus/ProviderLRCLIB.js
+++ b/CustomApps/lyrics-plus/ProviderLRCLIB.js
@@ -36,7 +36,7 @@ const ProviderLRCLIB = (() => {
 
 		if (!unsyncedLyrics) return null;
 
-		return Utils.parseLocalLyrics(syncedLyrics).unsynced;
+		return Utils.parseLocalLyrics(unsyncedLyrics).unsynced;
 	}
 
 	function getSynced(body) {

--- a/CustomApps/lyrics-plus/Providers.js
+++ b/CustomApps/lyrics-plus/Providers.js
@@ -31,7 +31,7 @@ const Providers = {
 			}));
 			result.unsynced = result.synced;
 		} else {
-			result.unsynced = lyrics.map(line => ({
+			result.unsynced = lines.map(line => ({
 				text: line.words
 			}));
 		}
@@ -40,7 +40,6 @@ const Providers = {
 
 		return result;
 	},
-
 	musixmatch: async info => {
 		const result = {
 			error: null,
@@ -91,7 +90,6 @@ const Providers = {
 
 		return result;
 	},
-
 	netease: async info => {
 		const result = {
 			uri: info.uri,
@@ -126,6 +124,37 @@ const Providers = {
 		const translation = ProviderNetease.getTranslation(list);
 		if (translation) {
 			result.neteaseTranslation = translation;
+		}
+
+		return result;
+	},
+	lrclib: async info => {
+		const result = {
+			uri: info.uri,
+			karaoke: null,
+			synced: null,
+			unsynced: null,
+			provider: "lrclib",
+			copyright: null
+		};
+
+		let list;
+		try {
+			list = await ProviderLRCLIB.findLyrics(info);
+		} catch {
+			result.error = "No lyrics";
+			return result;
+		}
+
+		const synced = ProviderLRCLIB.getSynced(list);
+		if (synced) {
+			result.synced = synced;
+		}
+
+		const unsynced = synced || ProviderLRCLIB.getUnsynced(list);
+
+		if (unsynced) {
+			result.unsynced = unsynced;
 		}
 
 		return result;

--- a/CustomApps/lyrics-plus/index.js
+++ b/CustomApps/lyrics-plus/index.js
@@ -72,6 +72,11 @@ const CONFIG = {
 			desc: "Crowdsourced lyrics provider ran by Chinese developers and users.",
 			modes: [KARAOKE, SYNCED, UNSYNCED]
 		},
+		lrclib: {
+			on: getConfig("lyrics-plus:provider:lrclib:on"),
+			desc: "Lyrics sourced from lrclib.net. Supports both synced and unsynced lyrics. LRCLIB is a free and open-source lyrics provider.",
+			modes: [SYNCED, UNSYNCED]
+		},
 		genius: {
 			on: spotifyVersion >= "1.2.31" ? false : getConfig("lyrics-plus:provider:genius:on"),
 			desc: "Provide unsynced lyrics with insights from artists themselves. Genius is disabled and cannot be used as a provider on <code>1.2.31</code> and higher.",

--- a/CustomApps/lyrics-plus/manifest.json
+++ b/CustomApps/lyrics-plus/manifest.json
@@ -71,6 +71,7 @@
 		"ProviderNetease.js",
 		"ProviderMusixmatch.js",
 		"ProviderGenius.js",
+		"ProviderLRCLIB.js",
 		"Providers.js",
 		"Pages.js",
 		"OptionsMenu.js",


### PR DESCRIPTION
We can't really send spicetify version in `User-Agent` because it's dropped by Chromium but I left it in the code anyways 🤷‍♀️

resolves https://github.com/spicetify/cli/issues/3027