### PR TITLE
fix(config): add spotify-launcher as a potential install path

### DIFF
--- a/src/utils/config.go
+++ b/src/utils/config.go
@@ -305,6 +305,7 @@ func linuxApp() string {
 		"/usr/libexec/spotify/",
 		"/var/lib/flatpak/app/com.spotify.Client/x86_64/stable/active/files/extra/share/spotify/",
 		"$HOME/.local/share/flatpak/app/com.spotify.Client/x86_64/stable/active/files/extra/share/spotify/",
+		"$HOME/.local/share/spotify-launcher/install/usr/share/spotify/",
 	}
 
 	for _, v := range potentialList {


### PR DESCRIPTION
On Arch Linux, `spotify-launcher` installs Spotify to a non-standard path, so this PR adds that location to the list of potential install paths.