### PR TITLE
feat(css-map): add selectors for `1.2.40` playbar

### DIFF
--- a/css-map.json
+++ b/css-map.json
@@ -1076,7 +1076,7 @@
 	"FTi9QEhetf4Q4__5sb4S": "npv-nowPlayingBar-right",
 	"SVGHXIQcH9HYU7uGITw5": "npv-nowPlayingBar-section",
 	"pn5V0OzovI9p6b8nWq8p": "playback-bar",
-	"B1vgcMXBqOxgMxXh5j1f": "playback-progressbar-container"
+	"B1vgcMXBqOxgMxXh5j1f": "playback-progressbar-container",
 	"p1ULRzPc4bD8eQ4T_wyp": "playback-progressbar",
 	"DFtdzavKSbEhwKYkPTa6": "playback-progressbar-isInteractive",
 	"JzyZE2R09wq7xtjECDeR": "playlist-inlineSearchBox-clearButton",

--- a/css-map.json
+++ b/css-map.json
@@ -1075,6 +1075,8 @@
 	"N5cWYDvyLrfnyMZuqQHo": "npv-nowPlayingBar-left",
 	"FTi9QEhetf4Q4__5sb4S": "npv-nowPlayingBar-right",
 	"SVGHXIQcH9HYU7uGITw5": "npv-nowPlayingBar-section",
+	"pn5V0OzovI9p6b8nWq8p": "playback-bar",
+	"B1vgcMXBqOxgMxXh5j1f": "playback-progressbar-container"
 	"p1ULRzPc4bD8eQ4T_wyp": "playback-progressbar",
 	"DFtdzavKSbEhwKYkPTa6": "playback-progressbar-isInteractive",
 	"JzyZE2R09wq7xtjECDeR": "playlist-inlineSearchBox-clearButton",


### PR DESCRIPTION
the reasoning for the brand new classname is spotify was using an unminified naming scheme for this element pre 1.2.40 - im simply re-adding their own classname they removed in the new update (playback-bar)

the reasoning for playback-progress-bar-container is self explanatory because in 1.2.40 playback-progressbar is now held within it