### PR TITLE
Fix(cmd): correct minor grammar mistake

### DIFF
--- a/src/cmd/cmd.go
+++ b/src/cmd/cmd.go
@@ -281,6 +281,6 @@ func CheckUpdate(version string) {
 		utils.PrintInfo("Spicetify up-to-date")
 	} else {
 		utils.PrintWarning("New version available: v" + latestTag + " (currently on: v" + version + ")")
-		utils.PrintWarning(`Run "spicetify update" or using package manager to update spicetify`)
+		utils.PrintWarning(`Run "spicetify update" or use a package manager to update spicetify`)
 	}
 }


### PR DESCRIPTION
Change the PrintWarning for the update function from `'Run "spicetify update" or using package manager to update spicetify'` to `'Run "spicetify update" or use a package manager to update spicetify'`