### PR TITLE
Fix(sidebarConfig): The sidebar config menu was incorrectly enabled on the global nav.

### DIFF
--- a/jsHelper/sidebarConfig.js
+++ b/jsHelper/sidebarConfig.js
@@ -168,26 +168,38 @@ color: var(--spice-button-disabled);
 		writeStorage();
 	}
 
-	(async () => {
-		await new Promise(res => Spicetify.Events.webpackLoaded.on(res));
-		new Spicetify.Menu.Item(
-			"Sidebar config",
-			false,
-			self => {
-				self.setState(!self.isEnabled);
-				if (self.isEnabled) {
-					injectInteraction();
-				} else {
-					removeInteraction();
-				}
-			},
-			`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="16px" height="16px" fill="currentcolor"><path d="M44.7,11L36,19.6c0,0-2.6,0-5.2-2.6s-2.6-5.2-2.6-5.2l8.7-8.7c-4.9-1.2-10.8,0.4-14.4,4c-5.4,5.4-0.6,12.3-2,13.7C12.9,28.7,5.1,34.7,4.9,35c-2.3,2.3-2.4,6-0.2,8.2c2.2,2.2,5.9,2.1,8.2-0.2c0.3-0.3,6.7-8.4,14.2-15.9c1.4-1.4,8,3.7,13.6-1.8C44.2,21.7,45.9,15.9,44.7,11z M9.4,41.1c-1.4,0-2.5-1.1-2.5-2.5C6.9,37.1,8,36,9.4,36c1.4,0,2.5,1.1,2.5,2.5C11.9,39.9,10.8,41.1,9.4,41.1z"/></svg>`
-		).register();
-	})();
+	const SidebarConfigMenu = new Spicetify.Menu.Item(
+		"Sidebar config",
+		false,
+		self => {
+			self.setState(!self.isEnabled);
+			if (self.isEnabled) {
+				injectInteraction();
+			} else {
+				removeInteraction();
+			}
+		},
+		`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="16px" height="16px" fill="currentcolor"><path d="M44.7,11L36,19.6c0,0-2.6,0-5.2-2.6s-2.6-5.2-2.6-5.2l8.7-8.7c-4.9-1.2-10.8,0.4-14.4,4c-5.4,5.4-0.6,12.3-2,13.7C12.9,28.7,5.1,34.7,4.9,35c-2.3,2.3-2.4,6-0.2,8.2c2.2,2.2,5.9,2.1,8.2-0.2c0.3-0.3,6.7-8.4,14.2-15.9c1.4-1.4,8,3.7,13.6-1.8C44.2,21.7,45.9,15.9,44.7,11z M9.4,41.1c-1.4,0-2.5-1.1-2.5-2.5C6.9,37.1,8,36,9.4,36c1.4,0,2.5,1.1,2.5,2.5C11.9,39.9,10.8,41.1,9.4,41.1z"/></svg>`
+	);
+
+	SidebarConfigMenu.addToMenu = () => {
+		SidebarConfigMenu.register();
+	};
+	SidebarConfigMenu.removeMenu = () => {
+		SidebarConfigMenu.setState(false);
+		SidebarConfigMenu.deregister();
+	};
 
 	function initConfig() {
+		SidebarConfigMenu.addToMenu();
+
 		const libraryX = document.querySelector(".main-yourLibraryX-navItems");
 		const libraryLegacy = document.querySelector(".main-navBar-entryPoints");
+		const globalNav = document.querySelector(".global-nav");
+
+		if (globalNav) {
+			SidebarConfigMenu.removeMenu();
+		}
 
 		if (!libraryLegacy && !libraryX) {
 			setTimeout(initConfig, 300);
@@ -318,7 +330,9 @@ color: var(--spice-button-disabled);
 		appendItems();
 	}
 
-	initConfig();
+	Spicetify.Events.webpackLoaded.on(() => {
+		initConfig();
+	});
 
 	// Rearrange sidebar when dynamically switching in Experimental Features
 	new MutationObserver(mutations => {


### PR DESCRIPTION
This fixes the side bar config menu incorrectly enabled on global nav now the menu shows only in libraryx and legacy 

context menu after global nav: 
![image](https://github.com/user-attachments/assets/aa695dac-1a9c-4c16-8323-ef483564115d)

context menu before global nav: 
![image](https://github.com/user-attachments/assets/bf3bb805-8ae0-4f2a-88a5-413156aba176)

context menu at library x remains same:
![image](https://github.com/user-attachments/assets/6a61592e-eb8a-404d-963d-c88d232ba649)
