### PR TITLE
feat(update): run `backup apply` for stock spotify

### DIFF
--- a/spicetify.go
+++ b/spicetify.go
@@ -254,7 +254,7 @@ func main() {
 
 		spotStat := spotifystatus.Get(spotifyPath)
 		if spotStat.IsBackupable() {
-			utils.PrintInfo("spicetify is already up-to-date! If you ran this command because spicetify disappeared after Spotify updated, we'll attempt to fix it for you right now.")
+			utils.PrintNote("spicetify is already up-to-date! If you ran this command because spicetify disappeared after Spotify updated, we'll attempt to fix it for you right now.")
 			cmd.Backup(version)
 			cmd.CheckStates()
 			cmd.InitSetting()

--- a/spicetify.go
+++ b/spicetify.go
@@ -253,7 +253,7 @@ func main() {
 		}
 
 		if spotStat.IsBackupable() {
-			utils.PrintInfo("spicetify is already up-to-date! If you're using this command because spicetify disappeared after Spotify updated, we'll attempt to fix it for you right now.")
+			utils.PrintInfo("spicetify is already up-to-date! If you ran this command because spicetify disappeared after Spotify updated, we'll attempt to fix it for you right now.")
 			cmd.Backup(version)
 			cmd.CheckStates()
 			cmd.InitSetting()

--- a/spicetify.go
+++ b/spicetify.go
@@ -253,7 +253,7 @@ func main() {
 		}
 
 		if spotStat.IsBackupable() {
-			utils.PrintInfo("Spicetify is already up-to-date! If you're using this command because Spicetify disappeared after Spotify updated, we'll attempt to fix it for you right now.")
+			utils.PrintInfo("spicetify is already up-to-date! If you're using this command because spicetify disappeared after Spotify updated, we'll attempt to fix it for you right now.")
 			cmd.Backup(version)
 			cmd.CheckStates()
 			cmd.InitSetting()

--- a/spicetify.go
+++ b/spicetify.go
@@ -233,13 +233,13 @@ func main() {
 	if slices.Contains(commands, "upgrade") || slices.Contains(commands, "update") {
 		updateStatus := cmd.Update(version)
 		spotifyPath := filepath.Join(utils.FindAppPath(), "Apps")
-		spotStat := spotifystatus.Get(spotifyPath)
 		ex, err := os.Executable()
 		if err != nil {
 			ex = "spicetify"
 		}
 
 		if updateStatus {
+			spotStat := spotifystatus.Get(spotifyPath)
 			cmds := []string{"backup", "apply"}
 			if !spotStat.IsBackupable() {
 				cmds = append([]string{"restore"}, cmds...)
@@ -252,6 +252,7 @@ func main() {
 			utils.CmdScanner(cmd)
 		}
 
+		spotStat := spotifystatus.Get(spotifyPath)
 		if spotStat.IsBackupable() {
 			utils.PrintInfo("spicetify is already up-to-date! If you ran this command because spicetify disappeared after Spotify updated, we'll attempt to fix it for you right now.")
 			cmd.Backup(version)
@@ -260,6 +261,7 @@ func main() {
 			cmd.Apply(version)
 			restartSpotify()
 		}
+
 		return
 	} else {
 		cmd.CheckUpdate(version)

--- a/spicetify.go
+++ b/spicetify.go
@@ -253,7 +253,7 @@ func main() {
 		}
 
 		if spotStat.IsBackupable() {
-			utils.PrintInfo("Spicetify is already up-to-date! If you're most likely running this command because Spicetify disappeared after Spotify updated, we'll attempt to fix it for you.")
+			utils.PrintInfo("Spicetify is already up-to-date! If you're using this command because Spicetify disappeared after Spotify updated, we'll attempt to fix it for you right now.")
 			cmd.Backup(version)
 			cmd.CheckStates()
 			cmd.InitSetting()


### PR DESCRIPTION
The reason for this change is that people assume spicetify has an update when spotify is in stock. This will only work when spotify is backupable. This change was voted positively in spicetify server.
![image](https://github.com/user-attachments/assets/6d7c26f1-5f69-453d-9724-e467b2c5d25e)

