### PR TITLE
fix(preprocess): disable sentry correctly and replace hex value

### DIFF
--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -186,7 +186,7 @@ func colorVariableReplace(content string) string {
 	utils.Replace(&content, "#121212", func(submatches ...string) string {
 		return "var(--spice-main)"
 	})
-	utils.Replace(&content, "#242424", func(submatches ...string) string {
+	utils.Replace(&content, `#(242424|1f1f1f)`, func(submatches ...string) string {
 		return "var(--spice-main-elevated)"
 	})
 
@@ -306,7 +306,7 @@ func colorVariableReplaceForJS(content string) string {
 }
 
 func disableSentry(input string) string {
-	utils.Replace(&input, `(\("[^"]+sentry.io)/`, func(submatches ...string) string {
+	utils.Replace(&input, `\(([^,]+),([^,]+),\{sampleRate:([^,]+),tracesSampleRate:([^,]+)(,.*?)?\}`, func(submatches ...string) string {
 		return fmt.Sprintf(",%s", submatches[0])
 	})
 	return input


### PR DESCRIPTION
According to @ohitstom, the `#242424` has become `#1f1f1f` in Spotify 1.2.43, thus we should replace both.

Sentry wasn't disabled for few(?) versions, so I updated the regex to work on new and old versions