### PR TITLE
fix(css-map): just fixing a typo

### DIFF
--- a/css-map.json
+++ b/css-map.json
@@ -1232,7 +1232,7 @@
 	"Nd2dSpwo9xYae8YuQIkb": "search-searchCategory-carouselButtonVisible",
 	"ZWI7JsjzJaR_G8Hy4W6J": "search-searchCategory-categoryGridItem",
 	"UnwG2v9ISmcUhnjKj22Y": "search-searchCategory-categoryGridItem",
-	"KjPUGV8uMbl_0bvk9ePv": "search-searchCategory-catergoryGrid",
+	"KjPUGV8uMbl_0bvk9ePv": "search-searchCategory-categoryGrid",
 	"e179_Eg8r7Ub6yjjxctr": "search-searchCategory-container",
 	"XAwhJzXeTM5Iv2jLMCEj": "search-searchCategory-container",
 	"bMurPtRDRv5LuN78MTVG": "search-searchCategory-contentArea",


### PR DESCRIPTION
Just fixed a single typo I noticed a little while back in the css-map ("search-searchCategory-cate**r**goryGrid" to "search-searchCategory-categoryGrid").

Saw it was still there and figured why not just fix it.