### PR TITLE
New-releases custom app: Stop close button propagation

### DIFF
--- a/CustomApps/new-releases/Card.js
+++ b/CustomApps/new-releases/Card.js
@@ -30,6 +30,8 @@ class Card extends react.Component {
 	}
 
 	closeButtonClicked(event) {
+		event.stopPropagation();
+
 		removeCards(this.props.uri);
 
 		Spicetify.Snackbar.enqueueCustomSnackbar
@@ -55,8 +57,6 @@ class Card extends react.Component {
 					}),
 				})
 			: Spicetify.showNotification(`Dismissed <b>${this.title}</b> from <br>${this.artist.name}</b>`);
-
-		event.stopPropagation();
 	}
 
 	render() {


### PR DESCRIPTION
Clicking the close button on a card in the new-releases custom app propagates and opens the album.

Stopping propagation first thing fixes the issue.