### PR TITLE
fix(shuffle+): update GraphQL handling

### DIFF
--- a/Extensions/shuffle+.js
+++ b/Extensions/shuffle+.js
@@ -338,7 +338,7 @@
 		if (errors) throw errors[0].message;
 		if (data.albumUnion.playability.playable === false) throw "Album is not playable";
 
-		return data.albumUnion.tracksV2.items.filter(({ track }) => track.playability.playable).map(({ track }) => (includeMetadata ? track : track.uri));
+		return (data.albumUnion?.tracksV2 ?? data.albumUnion?.tracks).items.filter(({ track }) => track.playability.playable).map(({ track }) => (includeMetadata ? track : track.uri));
 	}
 
 	const artistFetchTypeCount = { album: 0, single: 0 };
@@ -368,8 +368,13 @@
 	}
 
 	async function fetchArtistTracks(uri) {
-		const { queryArtistOverview } = Spicetify.GraphQL.Definitions;
-		// Definition from older Spotify version
+		// Definitions from older Spotify version
+        const queryArtistOverview = {
+			name: "queryArtistOverview",
+			operation: "query",
+			sha256Hash: "35648a112beb1794e39ab931365f6ae4a8d45e65396d641eeda94e4003d41497",
+			value: null,
+		};
 		const queryArtistDiscographyAll = {
 			name: "queryArtistDiscographyAll",
 			operation: "query",

--- a/Extensions/shuffle+.js
+++ b/Extensions/shuffle+.js
@@ -338,7 +338,7 @@
 		if (errors) throw errors[0].message;
 		if (data.albumUnion.playability.playable === false) throw "Album is not playable";
 
-		return data.albumUnion.tracks.items.filter(({ track }) => track.playability.playable).map(({ track }) => (includeMetadata ? track : track.uri));
+		return data.albumUnion.tracksV2.items.filter(({ track }) => track.playability.playable).map(({ track }) => (includeMetadata ? track : track.uri));
 	}
 
 	const artistFetchTypeCount = { album: 0, single: 0 };
@@ -368,12 +368,12 @@
 	}
 
 	async function fetchArtistTracks(uri) {
-		const { queryArtistDiscographyAll } = Spicetify.GraphQL.Definitions;
+		const { queryArtistOverview } = Spicetify.GraphQL.Definitions;
 		// Definition from older Spotify version
-		const queryArtistOverview = {
-			name: "queryArtistOverview",
+		const queryArtistDiscographyAll = {
+			name: "queryArtistDiscographyAll",
 			operation: "query",
-			sha256Hash: "35648a112beb1794e39ab931365f6ae4a8d45e65396d641eeda94e4003d41497",
+			sha256Hash: "9380995a9d4663cbcb5113fef3c6aabf70ae6d407ba61793fd01e2a1dd6929b0",
 			value: null,
 		};
 

--- a/Extensions/shuffle+.js
+++ b/Extensions/shuffle+.js
@@ -338,7 +338,9 @@
 		if (errors) throw errors[0].message;
 		if (data.albumUnion.playability.playable === false) throw "Album is not playable";
 
-		return (data.albumUnion?.tracksV2 ?? data.albumUnion?.tracks).items.filter(({ track }) => track.playability.playable).map(({ track }) => (includeMetadata ? track : track.uri));
+		return (data.albumUnion?.tracksV2 ?? data.albumUnion?.tracks ?? []).items
+			.filter(({ track }) => track.playability.playable)
+			.map(({ track }) => (includeMetadata ? track : track.uri));
 	}
 
 	const artistFetchTypeCount = { album: 0, single: 0 };
@@ -369,7 +371,7 @@
 
 	async function fetchArtistTracks(uri) {
 		// Definitions from older Spotify version
-        const queryArtistOverview = {
+		const queryArtistOverview = {
 			name: "queryArtistOverview",
 			operation: "query",
 			sha256Hash: "35648a112beb1794e39ab931365f6ae4a8d45e65396d641eeda94e4003d41497",


### PR DESCRIPTION
- Use `tracksV2` instead of `tracks` (if supported) when fetching album tracks
- Use hard-coded `queryArtistDiscographyAll` definition (due to Spotify v1.2.46; see [this PR](https://github.com/spicetify/cli/pull/3166))