### PR TITLE
feat(update): add support for shell GITHUB_TOKEN for GitHub API request

### DIFF
--- a/src/cmd/update.go
+++ b/src/cmd/update.go
@@ -64,10 +64,22 @@ func Update(currentVersion string) bool {
 	}
 	defer out.Close()
 
-	resp2, err := http.Get(assetURL)
+	req, err := http.NewRequest("GET", assetURL, nil)
 	if err != nil {
 		utils.Fatal(err)
 	}
+
+	githubToken := os.Getenv("GITHUB_TOKEN")
+	if githubToken != "" {
+		utils.PrintInfo("Using GITHUB_TOKEN as your PersonalAccesToken for GitHub request")
+		req.Header.Set("Authorization", "token "+githubToken)
+	}
+
+	resp2, err := http.DefaultClient.Do(req)
+	if err != nil {
+		utils.Fatal(err)
+	}
+	defer resp2.Body.Close()
 
 	_, err = io.Copy(out, resp2.Body)
 	if err != nil {

--- a/src/utils/vcs.go
+++ b/src/utils/vcs.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"os"
 )
 
 type GithubRelease struct {
@@ -13,10 +14,21 @@ type GithubRelease struct {
 }
 
 func FetchLatestTag() (string, error) {
-	res, err := http.Get("https://api.github.com/repos/spicetify/cli/releases/latest")
+	req, err := http.NewRequest("GET", "https://api.github.com/repos/spicetify/cli/releases/latest", nil)
 	if err != nil {
 		return "", err
 	}
+
+	githubToken := os.Getenv("GITHUB_TOKEN")
+	if githubToken != "" {
+		req.Header.Set("Authorization", "token "+githubToken)
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer res.Body.Close()
 
 	body, err := io.ReadAll(res.Body)
 	if err != nil {


### PR DESCRIPTION
## Pull Request: Add Support for GITHUB_TOKEN in Update & VCS

**Commits:**
- 0e9d91e6eb207938bfceb3a937e8c858c593a181 feat(vsc): add support for shell GITHUB_TOKEN for GitHub API request
- ff0ef17ca49ba4b562d92157b9b51a4bd66293cd feat(update): add support for shell GITHUB_TOKEN for GitHub API request

## Description
This pull request adds the ability to use the `GITHUB_TOKEN` environment variable for authenticated requests to the GitHub API. While this is not a complete solution to all github api requests e.g. its not for requests being made from the spotify interface via javascript, this does add an option to lessen the rate limit for purely terminal requests.

### Main changes
1. **`update.go`**
   - Replaced:
     ```go
     resp2, err := http.Get(assetURL)
     if err != nil {
       utils.Fatal(err)
     }
     ```
   - With:
     ```go
     req, err := http.NewRequest("GET", assetURL, nil)
     if err != nil {
       utils.Fatal(err)
     }

     githubToken := os.Getenv("GITHUB_TOKEN")
     if githubToken != "" {
       utils.PrintInfo("Using GITHUB_TOKEN as your PersonalAccesToken for GitHub request")
       req.Header.Set("Authorization", "token "+githubToken)
     }
     resp2, err := http.DefaultClient.Do(req)
     if err != nil {
       utils.Fatal(err)
     }
     defer resp2.Body.Close()
     ```

2. **`vcs.go`**
   - Replaced:
     ```go
     res, err := http.Get("https://api.github.com/repos/spicetify/cli/releases/latest")
     if err != nil {
       return "", err
     }
     ```
   - With:
     ```go
     req, err := http.NewRequest("GET", "https://api.github.com/repos/spicetify/cli/releases/latest", nil)
     if err != nil {
       return "", err
     }

     githubToken := os.Getenv("GITHUB_TOKEN")
     if githubToken != "" {
       req.Header.Set("Authorization", "token "+githubToken)
     }
     res, err := http.DefaultClient.Do(req)
     if err != nil {
       return "", err
     }
     defer res.Body.Close()
     ```
   - Added `import "os"` to access `os.Getenv`.

### Reasoning
- **Authentication**: Providing the `GITHUB_TOKEN` in HTTP headers allows authorized requests, which can bypass anonymous github rate limits.
- **Backwards Compatibility**: If no `GITHUB_TOKEN` is found, the request stays unauthenticated as before.

### How to Test
1. Temporarly set the `GITHUB_TOKEN` environment variable:
   ```bash
   export GITHUB_TOKEN=<your_token_here>
   ```
   
   