### PR TITLE
fix: Update keyboardShortcut.js

### DIFF
--- a/Extensions/keyboardShortcut.js
+++ b/Extensions/keyboardShortcut.js
@@ -55,7 +55,7 @@
 		"/": { callback: () => Spicetify.Platform.History.replace("/search") },
 
 		// CTRL + Arrow Left Next and CTRL + Arrow Right  Previous Song
-		"ctrl+left": { callback: () => Spicetify.Player.prev() },
+		"ctrl+left": { callback: () => Spicetify.Player.back() },
 		"ctrl+right": { callback: () => Spicetify.Player.next() },
 
 		// CTRL + Arrow Up Increase Volume CTRL + Arrow Down Decrease Volume


### PR DESCRIPTION
# issue
 - The shortcut for switching to the previous track in keyboardShortcut.js incorrectly calls Spicetify.Player.prev, a non-existent function, instead of Spicetify.Player.back.

Solves #3122, which was closed without proper testing of the extension.