### PR TITLE
feat(lyrics-plus): allow to change display of lyrics translation

### DIFF
--- a/CustomApps/lyrics-plus/OptionsMenu.js
+++ b/CustomApps/lyrics-plus/OptionsMenu.js
@@ -92,6 +92,13 @@ const TranslationMenu = react.memo(({ friendlyLanguage, hasTranslation }) => {
 			none: "None",
 		};
 
+		const savedTranslationDisplay = localStorage.getItem(`${APP_NAME}:visual:translate:display-mode`) || "replace";
+		CONFIG.visual["translate:display-mode"] = savedTranslationDisplay;
+		const translationDisplayOptions = {
+			replace: "Replace",
+			below: "Below",
+		};
+
 		const languageOptions = {
 			off: "Off",
 			"zh-hans": "Chinese (Simplified)",
@@ -149,6 +156,14 @@ const TranslationMenu = react.memo(({ friendlyLanguage, hasTranslation }) => {
 				key: "translate:translated-lyrics-source",
 				type: ConfigSelection,
 				options: sourceOptions,
+				renderInline: true,
+			},
+			{
+				desc: "Display",
+				key: "translate:display-mode",
+				type: ConfigSelection,
+				options: translationDisplayOptions,
+				defaultValue: savedTranslationDisplay,
 				renderInline: true,
 			},
 			{

--- a/CustomApps/lyrics-plus/Pages.js
+++ b/CustomApps/lyrics-plus/Pages.js
@@ -140,7 +140,7 @@ const SyncedLyricsPage = react.memo(({ lyrics = [], provider, copyright, isKara 
 				},
 				key: lyricsId,
 			},
-			activeLines.map(({ text, lineNumber, startTime }, i) => {
+			activeLines.map(({ text, lineNumber, startTime, originalText }, i) => {
 				if (i === 1 && activeLineIndex === 1) {
 					return react.createElement(IdlingIndicator, {
 						progress: position / activeLines[2].startTime,
@@ -169,33 +169,68 @@ const SyncedLyricsPage = react.memo(({ lyrics = [], provider, copyright, isKara 
 				if (paddingLine) {
 					className += " lyrics-lyricsContainer-LyricsLine-paddingLine";
 				}
+				const showTranslatedBelow = CONFIG.visual["translate:display-mode"] === "below";
+				// If we have original text and we are showing translated below, we should show the original text
+				// Otherwise we should show the translated text
+				const lineText = originalText && showTranslatedBelow ? originalText : text;
 
 				return react.createElement(
-					"p",
+					"div",
 					{
-						className,
-						style: {
-							cursor: "pointer",
-							"--position-index": animationIndex,
-							"--animation-index": (animationIndex < 0 ? 0 : animationIndex) + 1,
-							"--blur-index": Math.abs(animationIndex),
-						},
-						key: lineNumber,
-						dir: "auto",
-						ref,
-						onClick: (event) => {
-							if (startTime) {
-								Spicetify.Player.seek(startTime);
-							}
-						},
-						onContextMenu: (event) => {
-							event.preventDefault();
-							Spicetify.Platform.ClipboardAPI.copy(rawLyrics)
-								.then(() => Spicetify.showNotification("Lyrics copied to clipboard"))
-								.catch(() => Spicetify.showNotification("Failed to copy lyrics to clipboard"));
-						},
+						className: "lyrics-lyricsContainer-LyricsLineContainer",
+						key: i,
 					},
-					!isKara ? text : react.createElement(KaraokeLine, { text, startTime, position, isActive })
+					react.createElement(
+						"p",
+						{
+							className,
+							style: {
+								cursor: "pointer",
+								"--position-index": animationIndex,
+								"--animation-index": (animationIndex < 0 ? 0 : animationIndex) + 1,
+								"--blur-index": Math.abs(animationIndex),
+							},
+							key: lineNumber,
+							dir: "auto",
+							ref,
+							onClick: (event) => {
+								if (startTime) {
+									Spicetify.Player.seek(startTime);
+								}
+							},
+							onContextMenu: (event) => {
+								event.preventDefault();
+								Spicetify.Platform.ClipboardAPI.copy(rawLyrics)
+									.then(() => Spicetify.showNotification("Lyrics copied to clipboard"))
+									.catch(() => Spicetify.showNotification("Failed to copy lyrics to clipboard"));
+							},
+						},
+						!isKara ? lineText : react.createElement(KaraokeLine, { text, startTime, position, isActive })
+					),
+					showTranslatedBelow &&
+						originalText &&
+						originalText !== text &&
+						react.createElement(
+							"p",
+							{
+								className,
+								style: {
+									opacity: 0.5,
+									cursor: "pointer",
+									"--position-index": animationIndex,
+									"--animation-index": (animationIndex < 0 ? 0 : animationIndex) + 1,
+									"--blur-index": Math.abs(animationIndex),
+								},
+								dir: "auto",
+								ref,
+								onClick: (event) => {
+									if (startTime) {
+										Spicetify.Player.seek(startTime);
+									}
+								},
+							},
+							text
+						)
 				);
 			})
 		),
@@ -412,7 +447,7 @@ const SyncedExpandedLyricsPage = react.memo(({ lyrics, provider, copyright, isKa
 		react.createElement("p", {
 			className: "lyrics-lyricsContainer-LyricsUnsyncedPadding",
 		}),
-		padded.map(({ text, startTime }, i) => {
+		padded.map(({ text, startTime, originalText }, i) => {
 			if (i === 0) {
 				return react.createElement(IdlingIndicator, {
 					isActive: activeLineIndex === 0,
@@ -422,28 +457,57 @@ const SyncedExpandedLyricsPage = react.memo(({ lyrics, provider, copyright, isKa
 			}
 
 			const isActive = i === activeLineIndex;
+			const showTranslatedBelow = CONFIG.visual["translate:display-mode"] === "below";
+			// If we have original text and we are showing translated below, we should show the original text
+			// Otherwise we should show the translated text
+			const lineText = originalText && showTranslatedBelow ? originalText : text;
 			return react.createElement(
-				"p",
+				"div",
 				{
-					className: `lyrics-lyricsContainer-LyricsLine${i <= activeLineIndex ? " lyrics-lyricsContainer-LyricsLine-active" : ""}`,
-					style: {
-						cursor: "pointer",
-					},
-					dir: "auto",
-					ref: isActive ? activeLineRef : null,
-					onClick: (event) => {
-						if (startTime) {
-							Spicetify.Player.seek(startTime);
-						}
-					},
-					onContextMenu: (event) => {
-						event.preventDefault();
-						Spicetify.Platform.ClipboardAPI.copy(rawLyrics)
-							.then(() => Spicetify.showNotification("Lyrics copied to clipboard"))
-							.catch(() => Spicetify.showNotification("Failed to copy lyrics to clipboard"));
-					},
+					className: "lyrics-lyricsContainer-LyricsLineContainer",
+					key: i,
 				},
-				!isKara ? text : react.createElement(KaraokeLine, { text, startTime, position, isActive })
+				react.createElement(
+					"p",
+					{
+						className: `lyrics-lyricsContainer-LyricsLine${i <= activeLineIndex ? " lyrics-lyricsContainer-LyricsLine-active" : ""}`,
+						style: {
+							cursor: "pointer",
+						},
+						dir: "auto",
+						ref: isActive ? activeLineRef : null,
+						onClick: (event) => {
+							if (startTime) {
+								Spicetify.Player.seek(startTime);
+							}
+						},
+						onContextMenu: (event) => {
+							event.preventDefault();
+							Spicetify.Platform.ClipboardAPI.copy(rawLyrics)
+								.then(() => Spicetify.showNotification("Lyrics copied to clipboard"))
+								.catch(() => Spicetify.showNotification("Failed to copy lyrics to clipboard"));
+						},
+					},
+					!isKara ? lineText : react.createElement(KaraokeLine, { text, startTime, position, isActive })
+				),
+				showTranslatedBelow &&
+					originalText &&
+					originalText !== text &&
+					react.createElement(
+						"p",
+						{
+							className: `lyrics-lyricsContainer-LyricsLine${i <= activeLineIndex ? " lyrics-lyricsContainer-LyricsLine-active" : ""}`,
+							style: { opacity: 0.5, cursor: "pointer" },
+							dir: "auto",
+							ref: isActive ? activeLineRef : null,
+							onClick: (event) => {
+								if (startTime) {
+									Spicetify.Player.seek(startTime);
+								}
+							},
+						},
+						text
+					)
 			);
 		}),
 		react.createElement("p", {
@@ -468,20 +532,44 @@ const UnsyncedLyricsPage = react.memo(({ lyrics, provider, copyright }) => {
 		react.createElement("p", {
 			className: "lyrics-lyricsContainer-LyricsUnsyncedPadding",
 		}),
-		lyrics.map(({ text }) => {
+		lyrics.map(({ text, originalText }, index) => {
+			const showTranslatedBelow = CONFIG.visual["translate:display-mode"] === "below";
+			// If we have original text and we are showing translated below, we should show the original text
+			// Otherwise we should show the translated text
+			const lineText = originalText && showTranslatedBelow ? originalText : text;
+
 			return react.createElement(
-				"p",
+				"div",
 				{
-					className: "lyrics-lyricsContainer-LyricsLine lyrics-lyricsContainer-LyricsLine-active",
-					dir: "auto",
-					onContextMenu: (event) => {
-						event.preventDefault();
-						Spicetify.Platform.ClipboardAPI.copy(rawLyrics)
-							.then(() => Spicetify.showNotification("Lyrics copied to clipboard"))
-							.catch(() => Spicetify.showNotification("Failed to copy lyrics to clipboard"));
-					},
+					className: "lyrics-lyricsContainer-LyricsLineContainer",
+					key: index,
 				},
-				text
+				react.createElement(
+					"p",
+					{
+						className: "lyrics-lyricsContainer-LyricsLine lyrics-lyricsContainer-LyricsLine-active",
+						dir: "auto",
+						onContextMenu: (event) => {
+							event.preventDefault();
+							Spicetify.Platform.ClipboardAPI.copy(rawLyrics)
+								.then(() => Spicetify.showNotification("Lyrics copied to clipboard"))
+								.catch(() => Spicetify.showNotification("Failed to copy lyrics to clipboard"));
+						},
+					},
+					lineText
+				),
+				showTranslatedBelow &&
+					originalText &&
+					originalText !== text &&
+					react.createElement(
+						"p",
+						{
+							className: "lyrics-lyricsContainer-LyricsLine lyrics-lyricsContainer-LyricsLine-active",
+							style: { opacity: 0.5 },
+							dir: "auto",
+						},
+						text
+					)
 			);
 		}),
 		react.createElement("p", {

--- a/CustomApps/lyrics-plus/index.js
+++ b/CustomApps/lyrics-plus/index.js
@@ -41,6 +41,7 @@ const CONFIG = {
 		"lines-after": localStorage.getItem("lyrics-plus:visual:lines-after") || "2",
 		"font-size": localStorage.getItem("lyrics-plus:visual:font-size") || "32",
 		"translate:translated-lyrics-source": localStorage.getItem("lyrics-plus:visual:translate:translated-lyrics-source") || "none",
+		"translate:display-mode": localStorage.getItem("lyrics-plus:visual:translate:display-mode") || "replace",
 		"translate:detect-language-override": localStorage.getItem("lyrics-plus:visual:translate:detect-language-override") || "off",
 		"translation-mode:japanese": localStorage.getItem("lyrics-plus:visual:translation-mode:japanese") || "furigana",
 		"translation-mode:korean": localStorage.getItem("lyrics-plus:visual:translation-mode:korean") || "hangul",


### PR DESCRIPTION
This PR adds a new option to the lyrics-plus app to choose the display mode of the lyrics translation:

- Replace: Actual behavior, replacing the original lyrics with its translation
- Below: Display the original lyrics, and the translated line below in a lower opacity (as in the screen)

I'm not used to work on JS projects so I still have some small issues about this PR:
- Translated lines and behavior are repeated for each `UnsyncedLyricsPage`, `SyncedExpandedLyricsPage` `SyncedLyricsPage` and I feel like this could be refactored.
- I didn't now how to name the new option, because there is already a `Display Mode` so any suggestion to rename the option is welcomed
- When changing said option, it doesn't reload the lyrics div. It works when disabling and re-enabling the translation though.



![Display below](https://github.com/user-attachments/assets/49115454-8e74-49b6-81a1-4571de5621dd)
