### PR TITLE
feat(lyrics-plus): translation Below-mode Individual copy implementation

### DIFF
--- a/CustomApps/lyrics-plus/OptionsMenu.js
+++ b/CustomApps/lyrics-plus/OptionsMenu.js
@@ -92,8 +92,6 @@ const TranslationMenu = react.memo(({ friendlyLanguage, hasTranslation }) => {
 			none: "None",
 		};
 
-		const savedTranslationDisplay = localStorage.getItem(`${APP_NAME}:visual:translate:display-mode`) || "replace";
-		CONFIG.visual["translate:display-mode"] = savedTranslationDisplay;
 		const translationDisplayOptions = {
 			replace: "Replace original",
 			below: "Below original",
@@ -174,7 +172,6 @@ const TranslationMenu = react.memo(({ friendlyLanguage, hasTranslation }) => {
 					lyricContainerUpdate?.();
 				},
 				options: translationDisplayOptions,
-				defaultValue: savedTranslationDisplay,
 				renderInline: true,
 			},
 			{

--- a/CustomApps/lyrics-plus/OptionsMenu.js
+++ b/CustomApps/lyrics-plus/OptionsMenu.js
@@ -166,11 +166,6 @@ const TranslationMenu = react.memo(({ friendlyLanguage, hasTranslation }) => {
 				desc: "Translation Display",
 				key: "translate:display-mode",
 				type: ConfigSelection,
-				onChange: (name, value) => {
-					CONFIG.visual[name] = value;
-					localStorage.setItem(`${APP_NAME}:visual:${name}`, value);
-					lyricContainerUpdate?.();
-				},
 				options: translationDisplayOptions,
 				renderInline: true,
 			},

--- a/CustomApps/lyrics-plus/OptionsMenu.js
+++ b/CustomApps/lyrics-plus/OptionsMenu.js
@@ -228,7 +228,7 @@ const TranslationMenu = react.memo(({ friendlyLanguage, hasTranslation }) => {
 							items,
 							onChange: (name, value) => {
 								if (name === "translate:translated-lyrics-source") {
-									CONFIG.visual["translate"] = false;
+									CONFIG.visual.translate = false;
 									localStorage.setItem(`${APP_NAME}:visual:translate`, false);
 								}
 								if (name === "translate") {

--- a/CustomApps/lyrics-plus/OptionsMenu.js
+++ b/CustomApps/lyrics-plus/OptionsMenu.js
@@ -175,6 +175,8 @@ const TranslationMenu = react.memo(({ friendlyLanguage, hasTranslation }) => {
 				type: ConfigSelection,
 				options: languageOptions,
 				renderInline: true,
+				// for songs in languages that support translation but not Convert (e.g., English), the option is disabled.
+				when: () => friendlyLanguage,
 			},
 			{
 				desc: "Display Mode",
@@ -182,6 +184,8 @@ const TranslationMenu = react.memo(({ friendlyLanguage, hasTranslation }) => {
 				type: ConfigSelection,
 				options: modeOptions,
 				renderInline: true,
+				// for songs in languages that support translation but not Convert (e.g., English), the option is disabled.
+				when: () => friendlyLanguage,
 			},
 			{
 				desc: "Convert",
@@ -190,6 +194,8 @@ const TranslationMenu = react.memo(({ friendlyLanguage, hasTranslation }) => {
 				trigger: "click",
 				action: "toggle",
 				renderInline: true,
+				// for songs in languages that support translation but not Convert (e.g., English), the option is disabled.
+				when: () => friendlyLanguage,
 			},
 		];
 	}, [friendlyLanguage]);
@@ -227,7 +233,7 @@ const TranslationMenu = react.memo(({ friendlyLanguage, hasTranslation }) => {
 							type: "translation-menu",
 							items,
 							onChange: (name, value) => {
-								if (name === "translate:translated-lyrics-source") {
+								if (name === "translate:translated-lyrics-source" && friendlyLanguage) {
 									CONFIG.visual.translate = false;
 									localStorage.setItem(`${APP_NAME}:visual:translate`, false);
 								}

--- a/CustomApps/lyrics-plus/OptionsMenu.js
+++ b/CustomApps/lyrics-plus/OptionsMenu.js
@@ -227,6 +227,15 @@ const TranslationMenu = react.memo(({ friendlyLanguage, hasTranslation }) => {
 							type: "translation-menu",
 							items,
 							onChange: (name, value) => {
+								if (name === "translate:translated-lyrics-source") {
+									CONFIG.visual["translate"] = false;
+									localStorage.setItem(`${APP_NAME}:visual:translate`, false);
+								}
+								if (name === "translate") {
+									CONFIG.visual["translate:translated-lyrics-source"] = "none";
+									localStorage.setItem(`${APP_NAME}:visual:translate:translated-lyrics-source`, "none");
+								}
+
 								CONFIG.visual[name] = value;
 								localStorage.setItem(`${APP_NAME}:visual:${name}`, value);
 								lyricContainerUpdate?.();

--- a/CustomApps/lyrics-plus/Pages.js
+++ b/CustomApps/lyrics-plus/Pages.js
@@ -171,7 +171,12 @@ const SyncedLyricsPage = react.memo(({ lyrics = [], provider, copyright, isKara 
 				// If we have original text and we are showing translated below, we should show the original text
 				// Otherwise we should show the translated text
 				const lineText = originalText && showTranslatedBelow ? originalText : text;
-				const belowMode = showTranslatedBelow && originalText && originalText !== text;
+
+				// Convert lyrics to text for comparison
+				const belowOrigin = typeof originalText === "object" ? originalText?.props?.children?.[0] : originalText;
+				const belowTxt = typeof text === "object" ? text?.props?.children?.[0] : text;
+
+				const belowMode = showTranslatedBelow && originalText && belowOrigin !== belowTxt;
 
 				return react.createElement(
 					"div",
@@ -214,8 +219,8 @@ const SyncedLyricsPage = react.memo(({ lyrics = [], provider, copyright, isKara 
 								onContextMenu: (event) => {
 									event.preventDefault();
 									Spicetify.Platform.ClipboardAPI.copy(Utils.convertParsedToLRC(lyrics, belowMode).conver)
-										.then(() => Spicetify.showNotification("Lyrics copied to clipboard"))
-										.catch(() => Spicetify.showNotification("Failed to copy lyrics to clipboard"));
+										.then(() => Spicetify.showNotification("Translated lyrics copied to clipboard"))
+										.catch(() => Spicetify.showNotification("Failed to copy translated lyrics to clipboard"));
 								},
 							},
 							text
@@ -448,7 +453,12 @@ const SyncedExpandedLyricsPage = react.memo(({ lyrics, provider, copyright, isKa
 			// If we have original text and we are showing translated below, we should show the original text
 			// Otherwise we should show the translated text
 			const lineText = originalText && showTranslatedBelow ? originalText : text;
-			const belowMode = showTranslatedBelow && originalText && originalText !== text;
+
+			// Convert lyrics to text for comparison
+			const belowOrigin = typeof originalText === "object" ? originalText?.props?.children?.[0] : originalText;
+			const belowTxt = typeof text === "object" ? text?.props?.children?.[0] : text;
+
+			const belowMode = showTranslatedBelow && originalText && belowOrigin !== belowTxt;
 
 			return react.createElement(
 				"div",
@@ -486,8 +496,8 @@ const SyncedExpandedLyricsPage = react.memo(({ lyrics, provider, copyright, isKa
 							onContextMenu: (event) => {
 								event.preventDefault();
 								Spicetify.Platform.ClipboardAPI.copy(Utils.convertParsedToLRC(lyrics, belowMode).conver)
-									.then(() => Spicetify.showNotification("Lyrics copied to clipboard"))
-									.catch(() => Spicetify.showNotification("Failed to copy lyrics to clipboard"));
+									.then(() => Spicetify.showNotification("Translated lyrics copied to clipboard"))
+									.catch(() => Spicetify.showNotification("Failed to copy translated lyrics to clipboard"));
 							},
 						},
 						text
@@ -519,7 +529,12 @@ const UnsyncedLyricsPage = react.memo(({ lyrics, provider, copyright }) => {
 			// If we have original text and we are showing translated below, we should show the original text
 			// Otherwise we should show the translated text
 			const lineText = originalText && showTranslatedBelow ? originalText : text;
-			const belowMode = showTranslatedBelow && originalText && originalText !== text;
+
+			// Convert lyrics to text for comparison
+			const belowOrigin = typeof originalText === "object" ? originalText?.props?.children?.[0] : originalText;
+			const belowTxt = typeof text === "object" ? text?.props?.children?.[0] : text;
+
+			const belowMode = showTranslatedBelow && originalText && belowOrigin !== belowTxt;
 
 			return react.createElement(
 				"div",
@@ -548,8 +563,8 @@ const UnsyncedLyricsPage = react.memo(({ lyrics, provider, copyright }) => {
 							onContextMenu: (event) => {
 								event.preventDefault();
 								Spicetify.Platform.ClipboardAPI.copy(Utils.convertParsedToUnsynced(lyrics, belowMode).conver)
-									.then(() => Spicetify.showNotification("Lyrics copied to clipboard"))
-									.catch(() => Spicetify.showNotification("Failed to copy lyrics to clipboard"));
+									.then(() => Spicetify.showNotification("Translated lyrics copied to clipboard"))
+									.catch(() => Spicetify.showNotification("Failed to copy translated lyrics to clipboard"));
 							},
 						},
 						text

--- a/CustomApps/lyrics-plus/Pages.js
+++ b/CustomApps/lyrics-plus/Pages.js
@@ -123,8 +123,6 @@ const SyncedLyricsPage = react.memo(({ lyrics = [], provider, copyright, isKara 
 		offset += -(activeLineEle.current.offsetTop + activeLineEle.current.clientHeight / 2);
 	}
 
-	const rawLyrics = Utils.convertParsedToLRC(lyrics);
-
 	return react.createElement(
 		"div",
 		{
@@ -173,6 +171,7 @@ const SyncedLyricsPage = react.memo(({ lyrics = [], provider, copyright, isKara 
 				// If we have original text and we are showing translated below, we should show the original text
 				// Otherwise we should show the translated text
 				const lineText = originalText && showTranslatedBelow ? originalText : text;
+				const belowMode = showTranslatedBelow && originalText && originalText !== text;
 
 				return react.createElement(
 					"div",
@@ -192,22 +191,31 @@ const SyncedLyricsPage = react.memo(({ lyrics = [], provider, copyright, isKara 
 								Spicetify.Player.seek(startTime);
 							}
 						},
-						onContextMenu: (event) => {
-							event.preventDefault();
-							Spicetify.Platform.ClipboardAPI.copy(rawLyrics)
-								.then(() => Spicetify.showNotification("Lyrics copied to clipboard"))
-								.catch(() => Spicetify.showNotification("Failed to copy lyrics to clipboard"));
-						},
 					},
-					react.createElement("p", {}, !isKara ? lineText : react.createElement(KaraokeLine, { text, startTime, position, isActive })),
-					showTranslatedBelow &&
-						originalText &&
-						originalText !== text &&
+					react.createElement(
+						"p",
+						{
+							onContextMenu: (event) => {
+								event.preventDefault();
+								Spicetify.Platform.ClipboardAPI.copy(Utils.convertParsedToLRC(lyrics, belowMode).original)
+									.then(() => Spicetify.showNotification("Lyrics copied to clipboard"))
+									.catch(() => Spicetify.showNotification("Failed to copy lyrics to clipboard"));
+							},
+						},
+						!isKara ? lineText : react.createElement(KaraokeLine, { text, startTime, position, isActive })
+					),
+					belowMode &&
 						react.createElement(
 							"p",
 							{
 								style: {
 									opacity: 0.5,
+								},
+								onContextMenu: (event) => {
+									event.preventDefault();
+									Spicetify.Platform.ClipboardAPI.copy(Utils.convertParsedToLRC(lyrics, belowMode).conver)
+										.then(() => Spicetify.showNotification("Lyrics copied to clipboard"))
+										.catch(() => Spicetify.showNotification("Failed to copy lyrics to clipboard"));
 								},
 							},
 							text
@@ -405,8 +413,6 @@ const SyncedExpandedLyricsPage = react.memo(({ lyrics, provider, copyright, isKa
 		}
 	}
 
-	const rawLyrics = Utils.convertParsedToLRC(lyrics);
-
 	useEffect(() => {
 		if (activeLineRef.current && (!intialScroll[0] || isInViewport(activeLineRef.current))) {
 			activeLineRef.current.scrollIntoView({
@@ -442,6 +448,8 @@ const SyncedExpandedLyricsPage = react.memo(({ lyrics, provider, copyright, isKa
 			// If we have original text and we are showing translated below, we should show the original text
 			// Otherwise we should show the translated text
 			const lineText = originalText && showTranslatedBelow ? originalText : text;
+			const belowMode = showTranslatedBelow && originalText && originalText !== text;
+
 			return react.createElement(
 				"div",
 				{
@@ -457,21 +465,30 @@ const SyncedExpandedLyricsPage = react.memo(({ lyrics, provider, copyright, isKa
 							Spicetify.Player.seek(startTime);
 						}
 					},
-					onContextMenu: (event) => {
-						event.preventDefault();
-						Spicetify.Platform.ClipboardAPI.copy(rawLyrics)
-							.then(() => Spicetify.showNotification("Lyrics copied to clipboard"))
-							.catch(() => Spicetify.showNotification("Failed to copy lyrics to clipboard"));
-					},
 				},
-				react.createElement("p", {}, !isKara ? lineText : react.createElement(KaraokeLine, { text, startTime, position, isActive })),
-				showTranslatedBelow &&
-					originalText &&
-					originalText !== text &&
+				react.createElement(
+					"p",
+					{
+						onContextMenu: (event) => {
+							event.preventDefault();
+							Spicetify.Platform.ClipboardAPI.copy(Utils.convertParsedToLRC(lyrics, belowMode).original)
+								.then(() => Spicetify.showNotification("Lyrics copied to clipboard"))
+								.catch(() => Spicetify.showNotification("Failed to copy lyrics to clipboard"));
+						},
+					},
+					!isKara ? lineText : react.createElement(KaraokeLine, { text, startTime, position, isActive })
+				),
+				belowMode &&
 					react.createElement(
 						"p",
 						{
 							style: { opacity: 0.5 },
+							onContextMenu: (event) => {
+								event.preventDefault();
+								Spicetify.Platform.ClipboardAPI.copy(Utils.convertParsedToLRC(lyrics, belowMode).conver)
+									.then(() => Spicetify.showNotification("Lyrics copied to clipboard"))
+									.catch(() => Spicetify.showNotification("Failed to copy lyrics to clipboard"));
+							},
 						},
 						text
 					)
@@ -489,8 +506,6 @@ const SyncedExpandedLyricsPage = react.memo(({ lyrics, provider, copyright, isKa
 });
 
 const UnsyncedLyricsPage = react.memo(({ lyrics, provider, copyright }) => {
-	const rawLyrics = lyrics.map((lyrics) => (typeof lyrics.text !== "object" ? lyrics.text : lyrics.text?.props?.children?.[0])).join("\n");
-
 	return react.createElement(
 		"div",
 		{
@@ -504,6 +519,7 @@ const UnsyncedLyricsPage = react.memo(({ lyrics, provider, copyright }) => {
 			// If we have original text and we are showing translated below, we should show the original text
 			// Otherwise we should show the translated text
 			const lineText = originalText && showTranslatedBelow ? originalText : text;
+			const belowMode = showTranslatedBelow && originalText && originalText !== text;
 
 			return react.createElement(
 				"div",
@@ -511,21 +527,30 @@ const UnsyncedLyricsPage = react.memo(({ lyrics, provider, copyright }) => {
 					className: "lyrics-lyricsContainer-LyricsLine lyrics-lyricsContainer-LyricsLine-active",
 					key: index,
 					dir: "auto",
-					onContextMenu: (event) => {
-						event.preventDefault();
-						Spicetify.Platform.ClipboardAPI.copy(rawLyrics)
-							.then(() => Spicetify.showNotification("Lyrics copied to clipboard"))
-							.catch(() => Spicetify.showNotification("Failed to copy lyrics to clipboard"));
-					},
 				},
-				react.createElement("p", {}, lineText),
-				showTranslatedBelow &&
-					originalText &&
-					originalText !== text &&
+				react.createElement(
+					"p",
+					{
+						onContextMenu: (event) => {
+							event.preventDefault();
+							Spicetify.Platform.ClipboardAPI.copy(Utils.convertParsedToUnsynced(lyrics, belowMode).original)
+								.then(() => Spicetify.showNotification("Lyrics copied to clipboard"))
+								.catch(() => Spicetify.showNotification("Failed to copy lyrics to clipboard"));
+						},
+					},
+					lineText
+				),
+				belowMode &&
 					react.createElement(
 						"p",
 						{
 							style: { opacity: 0.5 },
+							onContextMenu: (event) => {
+								event.preventDefault();
+								Spicetify.Platform.ClipboardAPI.copy(Utils.convertParsedToUnsynced(lyrics, belowMode).conver)
+									.then(() => Spicetify.showNotification("Lyrics copied to clipboard"))
+									.catch(() => Spicetify.showNotification("Failed to copy lyrics to clipboard"));
+							},
 						},
 						text
 					)

--- a/CustomApps/lyrics-plus/Settings.js
+++ b/CustomApps/lyrics-plus/Settings.js
@@ -512,6 +512,7 @@ const OptionList = ({ type, items, onChange }) => {
 		);
 	});
 };
+
 const languageCodes =
 	"none,en,af,ar,bg,bn,ca,zh,cs,da,de,el,es,et,fa,fi,fr,gu,he,hi,hr,hu,id,is,it,ja,jv,kn,ko,lt,lv,ml,mr,ms,nl,no,pl,pt,ro,ru,sk,sl,sr,su,sv,ta,te,th,tr,uk,ur,vi,zu".split(
 		","
@@ -522,9 +523,6 @@ const languageOptions = languageCodes.reduce((acc, code) => {
 	acc[code] = code === "none" ? "None" : displayNames.of(code);
 	return acc;
 }, {});
-
-const savedLanguage = localStorage.getItem(`${APP_NAME}:visual:musixmatch-translation-language`) || "none";
-CONFIG.visual["musixmatch-translation-language"] = savedLanguage;
 
 function openConfig() {
 	const configContainer = react.createElement(
@@ -649,7 +647,6 @@ function openConfig() {
 					key: "musixmatch-translation-language",
 					type: ConfigSelection,
 					options: languageOptions,
-					defaultValue: savedLanguage,
 				},
 			],
 			onChange: (name, value) => {
@@ -665,6 +662,11 @@ function openConfig() {
 					},
 				});
 				window.dispatchEvent(configChange);
+
+				// Reload page if translation language is changed
+				if (name === "musixmatch-translation-language") {
+					window.location.reload();
+				}
 			},
 		}),
 		react.createElement("h2", null, "Providers"),

--- a/CustomApps/lyrics-plus/Settings.js
+++ b/CustomApps/lyrics-plus/Settings.js
@@ -643,7 +643,7 @@ function openConfig() {
 				},
 				{
 					desc: "Musixmatch Translation Language.",
-					info: "Choose the language you want to translate the lyrics to. Changes will take effect after the next track.",
+					info: "Choose the language you want to translate the lyrics to. When the language is changed, the page reloads.",
 					key: "musixmatch-translation-language",
 					type: ConfigSelection,
 					options: languageOptions,

--- a/CustomApps/lyrics-plus/Settings.js
+++ b/CustomApps/lyrics-plus/Settings.js
@@ -652,7 +652,13 @@ function openConfig() {
 			onChange: (name, value) => {
 				CONFIG.visual[name] = value;
 				localStorage.setItem(`${APP_NAME}:visual:${name}`, value);
-				lyricContainerUpdate?.();
+
+				// Reload Lyrics if translation language is changed
+				if (name === "musixmatch-translation-language") {
+					reloadLyrics?.();
+				} else {
+					lyricContainerUpdate?.();
+				}
 
 				const configChange = new CustomEvent("lyrics-plus", {
 					detail: {
@@ -662,11 +668,6 @@ function openConfig() {
 					},
 				});
 				window.dispatchEvent(configChange);
-
-				// Reload page if translation language is changed
-				if (name === "musixmatch-translation-language") {
-					window.location.reload();
-				}
 			},
 		}),
 		react.createElement("h2", null, "Providers"),
@@ -675,15 +676,17 @@ function openConfig() {
 			onListChange: (list) => {
 				CONFIG.providersOrder = list;
 				localStorage.setItem(`${APP_NAME}:services-order`, JSON.stringify(list));
+				reloadLyrics?.();
 			},
 			onToggle: (name, value) => {
 				CONFIG.providers[name].on = value;
 				localStorage.setItem(`${APP_NAME}:provider:${name}:on`, value);
-				lyricContainerUpdate?.();
+				reloadLyrics?.();
 			},
 			onTokenChange: (name, value) => {
 				CONFIG.providers[name].token = value;
 				localStorage.setItem(`${APP_NAME}:provider:${name}:token`, value);
+				reloadLyrics?.();
 			},
 		}),
 		react.createElement("h2", null, "CORS Proxy Template"),

--- a/CustomApps/lyrics-plus/Settings.js
+++ b/CustomApps/lyrics-plus/Settings.js
@@ -111,7 +111,6 @@ const ConfigSlider = ({ name, defaultValue, onChange = () => {} }) => {
 
 	useEffect(() => {
 		setActive(defaultValue);
-		onChange(defaultValue);
 	}, [defaultValue]);
 
 	const toggleState = useCallback(() => {
@@ -648,7 +647,7 @@ function openConfig() {
 				},
 				{
 					desc: "Musixmatch Translation Language.",
-					info: "Choose the language you want to translate the lyrics to. When the language is changed, the page reloads.",
+					info: "Choose the language you want to translate the lyrics to. When the language is changed, the lyrics reloads.",
 					key: "musixmatch-translation-language",
 					type: ConfigSelection,
 					options: languageOptions,

--- a/CustomApps/lyrics-plus/Settings.js
+++ b/CustomApps/lyrics-plus/Settings.js
@@ -109,6 +109,11 @@ const RefreshTokenButton = ({ setTokenCallback }) => {
 const ConfigSlider = ({ name, defaultValue, onChange = () => {} }) => {
 	const [active, setActive] = useState(defaultValue);
 
+	useEffect(() => {
+		setActive(defaultValue);
+		onChange(defaultValue);
+	}, [defaultValue]);
+
 	const toggleState = useCallback(() => {
 		const state = !active;
 		setActive(state);

--- a/CustomApps/lyrics-plus/Utils.js
+++ b/CustomApps/lyrics-plus/Utils.js
@@ -96,7 +96,7 @@ const Utils = {
 		// Should return IETF BCP 47 language tags.
 		// This should detect the song's main language.
 		// Remember there is a possibility of a song referencing something in another language and the lyrics show it in that native language!
-		const rawLyrics = lyrics.map((line) => line.text).join(" ");
+		const rawLyrics = lyrics[0].originalText ? lyrics.map((line) => line.originalText).join(" ") : lyrics.map((line) => line.text).join(" ");
 
 		const kanaRegex = /[\u3001-\u3003]|[\u3005\u3007]|[\u301d-\u301f]|[\u3021-\u3035]|[\u3038-\u303a]|[\u3040-\u30ff]|[\uff66-\uff9f]/gu;
 		const hangulRegex = /(\S*[\u3131-\u314e|\u314f-\u3163|\uac00-\ud7a3]+\S*)/g;

--- a/CustomApps/lyrics-plus/Utils.js
+++ b/CustomApps/lyrics-plus/Utils.js
@@ -222,13 +222,45 @@ const Utils = {
 		}
 		return text;
 	},
-	convertParsedToLRC(lyrics) {
-		return lyrics
-			.map((line) => {
-				if (!line.startTime) return line.text;
-				return `[${this.formatTime(line.startTime)}]${this.formatTextWithTimestamps(line.text, line.startTime)}`;
-			})
-			.join("\n");
+	convertParsedToLRC(lyrics, isBelow) {
+		let original = "";
+		let conver = "";
+
+		if (isBelow) {
+			lyrics.forEach((line) => {
+				original += `[${this.formatTime(line.startTime)}]${this.formatTextWithTimestamps(line.originalText, line.startTime)}\n`;
+				conver += `[${this.formatTime(line.startTime)}]${this.formatTextWithTimestamps(line.text, line.startTime)}\n`;
+			});
+		} else {
+			lyrics.forEach((line) => {
+				original += `[${this.formatTime(line.startTime)}]${this.formatTextWithTimestamps(line.text, line.startTime)}\n`;
+			});
+		}
+
+		return {
+			original,
+			conver,
+		};
+	},
+	convertParsedToUnsynced(lyrics, isBelow) {
+		let original = "";
+		let conver = "";
+
+		if (isBelow) {
+			lyrics.forEach((line) => {
+				typeof line.originalText !== "object" ? (original += `${line.originalText}\n`) : (original += `${line.originalText?.props?.children?.[0]}\n`);
+				typeof line.text !== "object" ? (conver += `${line.text}\n`) : (conver += `${line.text?.props?.children?.[0]}\n`);
+			});
+		} else {
+			lyrics.forEach((line) => {
+				typeof line.text !== "object" ? (original += `${line.text}\n`) : (original += `${line.text?.props?.children?.[0]}\n`);
+			});
+		}
+
+		return {
+			original,
+			conver,
+		};
 	},
 	parseLocalLyrics(lyrics) {
 		// Preprocess lyrics by removing [tags] and empty lines

--- a/CustomApps/lyrics-plus/Utils.js
+++ b/CustomApps/lyrics-plus/Utils.js
@@ -227,14 +227,14 @@ const Utils = {
 		let conver = "";
 
 		if (isBelow) {
-			lyrics.forEach((line) => {
+			for (const line of lyrics) {
 				original += `[${this.formatTime(line.startTime)}]${this.formatTextWithTimestamps(line.originalText, line.startTime)}\n`;
 				conver += `[${this.formatTime(line.startTime)}]${this.formatTextWithTimestamps(line.text, line.startTime)}\n`;
-			});
+			}
 		} else {
-			lyrics.forEach((line) => {
+			for (const line of lyrics) {
 				original += `[${this.formatTime(line.startTime)}]${this.formatTextWithTimestamps(line.text, line.startTime)}\n`;
-			});
+			}
 		}
 
 		return {
@@ -247,14 +247,27 @@ const Utils = {
 		let conver = "";
 
 		if (isBelow) {
-			lyrics.forEach((line) => {
-				typeof line.originalText !== "object" ? (original += `${line.originalText}\n`) : (original += `${line.originalText?.props?.children?.[0]}\n`);
-				typeof line.text !== "object" ? (conver += `${line.text}\n`) : (conver += `${line.text?.props?.children?.[0]}\n`);
-			});
+			for (const line of lyrics) {
+				if (line.originalText !== "object") {
+					original += `${line.originalText}\n`;
+				} else {
+					original += `${line.originalText?.props?.children?.[0]}\n`;
+				}
+
+				if (line.text !== "object") {
+					conver += `${line.text}\n`;
+				} else {
+					conver += `${line.text?.props?.children?.[0]}\n`;
+				}
+			}
 		} else {
-			lyrics.forEach((line) => {
-				typeof line.text !== "object" ? (original += `${line.text}\n`) : (original += `${line.text?.props?.children?.[0]}\n`);
-			});
+			for (const line of lyrics) {
+				if (line.text !== "object") {
+					original += `${line.text}\n`;
+				} else {
+					original += `${line.text?.props?.children?.[0]}\n`;
+				}
+			}
 		}
 
 		return {

--- a/CustomApps/lyrics-plus/Utils.js
+++ b/CustomApps/lyrics-plus/Utils.js
@@ -139,10 +139,12 @@ const Utils = {
 			const lyric = {
 				startTime: lyricsToTranslate[i].startTime || 0,
 				text: this.rubyTextToReact(translatedLines[i]),
+				originalText: lyricsToTranslate[i].text,
 			};
 			state[stateName].push(lyric);
 		}
 	},
+	/** It seems that this function is not being used, but I'll keep it just in case it’s needed in the future.*/
 	processTranslatedOriginalLyrics(lyrics, synced) {
 		const data = [];
 		const dataSouce = {};
@@ -248,24 +250,24 @@ const Utils = {
 
 		if (isBelow) {
 			for (const line of lyrics) {
-				if (line.originalText !== "object") {
-					original += `${line.originalText}\n`;
-				} else {
+				if (typeof line.originalText === "object") {
 					original += `${line.originalText?.props?.children?.[0]}\n`;
+				} else {
+					original += `${line.originalText}\n`;
 				}
 
-				if (line.text !== "object") {
-					conver += `${line.text}\n`;
-				} else {
+				if (typeof line.text === "object") {
 					conver += `${line.text?.props?.children?.[0]}\n`;
+				} else {
+					conver += `${line.text}\n`;
 				}
 			}
 		} else {
 			for (const line of lyrics) {
-				if (line.text !== "object") {
-					original += `${line.text}\n`;
-				} else {
+				if (typeof line.text === "object") {
 					original += `${line.text?.props?.children?.[0]}\n`;
+				} else {
+					original += `${line.text}\n`;
 				}
 			}
 		}

--- a/CustomApps/lyrics-plus/index.js
+++ b/CustomApps/lyrics-plus/index.js
@@ -180,6 +180,7 @@ class LyricsContainer extends react.Component {
 		this.translationProvider = CONFIG.visual["translate:translated-lyrics-source"];
 		this.languageOverride = CONFIG.visual["translate:detect-language-override"];
 		this.translate = CONFIG.visual.translate;
+		this.reRenderLyricsPage = false;
 	}
 
 	infoFromTrack(track) {
@@ -610,6 +611,7 @@ class LyricsContainer extends react.Component {
 		Utils.addQueueListener(this.onQueueChange);
 
 		lyricContainerUpdate = () => {
+			this.reRenderLyricsPage = !this.reRenderLyricsPage;
 			this.updateVisualOnConfigChange();
 			this.forceUpdate();
 		};
@@ -789,6 +791,7 @@ class LyricsContainer extends react.Component {
 					lyrics: this.state.karaoke,
 					provider: this.state.provider,
 					copyright: this.state.copyright,
+					reRenderLyricsPage: this.reRenderLyricsPage,
 				});
 			} else if (mode === SYNCED && this.state.synced) {
 				activeItem = react.createElement(CONFIG.visual["synced-compact"] ? SyncedLyricsPage : SyncedExpandedLyricsPage, {
@@ -796,6 +799,7 @@ class LyricsContainer extends react.Component {
 					lyrics: CONFIG.visual.translate && translatedLyrics ? translatedLyrics : this.state.currentLyrics,
 					provider: this.state.provider,
 					copyright: this.state.copyright,
+					reRenderLyricsPage: this.reRenderLyricsPage,
 				});
 			} else if (mode === UNSYNCED && this.state.unsynced) {
 				activeItem = react.createElement(UnsyncedLyricsPage, {
@@ -803,6 +807,7 @@ class LyricsContainer extends react.Component {
 					lyrics: CONFIG.visual.translate && translatedLyrics ? translatedLyrics : this.state.currentLyrics,
 					provider: this.state.provider,
 					copyright: this.state.copyright,
+					reRenderLyricsPage: this.reRenderLyricsPage,
 				});
 			} else if (mode === GENIUS && this.state.genius) {
 				activeItem = react.createElement(GeniusPage, {
@@ -817,6 +822,7 @@ class LyricsContainer extends react.Component {
 					lyrics2: this.state.genius2,
 					versionIndex2: this.state.versionIndex2,
 					onVersionChange2: this.onVersionChange2.bind(this),
+					reRenderLyricsPage: this.reRenderLyricsPage,
 				});
 			}
 		}

--- a/CustomApps/lyrics-plus/index.js
+++ b/CustomApps/lyrics-plus/index.js
@@ -49,6 +49,7 @@ const CONFIG = {
 		translate: getConfig("lyrics-plus:visual:translate", false),
 		"ja-detect-threshold": localStorage.getItem("lyrics-plus:visual:ja-detect-threshold") || "40",
 		"hans-detect-threshold": localStorage.getItem("lyrics-plus:visual:hans-detect-threshold") || "40",
+		"musixmatch-translation-language": localStorage.getItem("lyrics-plus:visual:musixmatch-translation-language") || "none",
 		"fade-blur": getConfig("lyrics-plus:visual:fade-blur"),
 		"fullscreen-key": localStorage.getItem("lyrics-plus:visual:fullscreen-key") || "f12",
 		"synced-compact": getConfig("lyrics-plus:visual:synced-compact"),

--- a/CustomApps/lyrics-plus/index.js
+++ b/CustomApps/lyrics-plus/index.js
@@ -112,7 +112,7 @@ CONFIG.visual["font-size"] = Number.parseInt(CONFIG.visual["font-size"]);
 CONFIG.visual["ja-detect-threshold"] = Number.parseInt(CONFIG.visual["ja-detect-threshold"]);
 CONFIG.visual["hans-detect-threshold"] = Number.parseInt(CONFIG.visual["hans-detect-threshold"]);
 
-const CACHE = {};
+let CACHE = {};
 
 const emptyState = {
 	karaoke: null,
@@ -124,6 +124,7 @@ const emptyState = {
 };
 
 let lyricContainerUpdate;
+let reloadLyrics;
 
 const fontSizeLimit = { min: 16, max: 256, step: 4 };
 
@@ -614,6 +615,13 @@ class LyricsContainer extends react.Component {
 			this.reRenderLyricsPage = !this.reRenderLyricsPage;
 			this.updateVisualOnConfigChange();
 			this.forceUpdate();
+		};
+
+		reloadLyrics = () => {
+			CACHE = {};
+			this.updateVisualOnConfigChange();
+			this.forceUpdate();
+			this.fetchLyrics(Spicetify.Player.data.item, this.state.explicitMode);
 		};
 
 		this.viewPort =


### PR DESCRIPTION
If the lyrics are in Below-mode, the original lyrics or the translated lyrics can now be copy depending on the cursor position.

Additionally, when changing the `musixmatch translation language` in `lyrics plus config`, the page is now designed to re-load, allowing the translation feature to be used without switching to the next song.

And minor bugs were fixed, and unnecessary code was revised

- lyrics copy

https://github.com/user-attachments/assets/62d9a1d9-ba06-42ea-9bc9-2159109f0bbf


- musixmatch translation language change

https://github.com/user-attachments/assets/dda2972c-3a28-4c87-8bbf-8dac628c3f18

