### PR TITLE
fix(lyrics-plus): properly check for `none` value in trans lang

### DIFF
--- a/CustomApps/lyrics-plus/OptionsMenu.js
+++ b/CustomApps/lyrics-plus/OptionsMenu.js
@@ -111,6 +111,7 @@ const TranslationMenu = react.memo(({ friendlyLanguage, hasTranslation }) => {
 
 		if (hasTranslation.musixmatch) {
 			const selectedLanguage = CONFIG.visual["musixmatch-translation-language"];
+			if (selectedLanguage === "none") return;
 			const languageName = new Intl.DisplayNames([selectedLanguage], {
 				type: "language",
 			}).of(selectedLanguage);

--- a/CustomApps/lyrics-plus/Settings.js
+++ b/CustomApps/lyrics-plus/Settings.js
@@ -699,6 +699,10 @@ function openConfig() {
 
 				// Reload Lyrics if translation language is changed
 				if (name === "musixmatch-translation-language") {
+					if (value === "none") {
+						CONFIG.visual["translate:translated-lyrics-source"] = "none";
+						localStorage.setItem(`${APP_NAME}:visual:translate:translated-lyrics-source`, "none");
+					}
 					reloadLyrics?.();
 				} else {
 					lyricContainerUpdate?.();


### PR DESCRIPTION
fix an issue where reverting to none after applying a translation caused an error.