### PR TITLE
Add a check for offline.bnk in the home dir of the user.

### DIFF
--- a/src/cmd/devtools.go
+++ b/src/cmd/devtools.go
@@ -40,6 +40,9 @@ func SetDevTools() {
 				filePath = homePath + "/.cache/spotify/offline.bnk"
 			}
 
+			if _, err := os.Stat(homePath + "/.cache/spotify/offline.bnk"); err == nil {
+				filePath = homePath + "/.cache/spotify/offline.bnk"
+			}
 		}
 	case "darwin":
 		filePath = os.Getenv("HOME") + "/Library/Application Support/Spotify/PersistentCache/offline.bnk"


### PR DESCRIPTION
If you install spotify from other methods than snap or flatpak, your offline.bnk will probably be in your home dir (~/.cache/spotify). This adds a check for that.