### PR TITLE
fix: add `$lineClamp` key to styled components processing

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1205,6 +1205,7 @@ Spicetify._getStyledClassName = (args, component) => {
 		"$buttonSize",
 		"$position",
 		"$iconSize",
+		"$lineClamp",
 	];
 	const customKeys = ["blocksize"];
 	const customExactKeys = ["$padding", "$paddingBottom", "paddingBottom", "padding"];


### PR DESCRIPTION
PR fixes issue with line-clamp css property on playlist sidebar compact view (comparison on image)
![comparison](https://github.com/user-attachments/assets/2d69fe2a-6dea-4099-a42c-5721ec9a9acf)
