### PR TITLE
feat(lyrics-plus/netease): implement below-mode for netease

### DIFF
--- a/CustomApps/lyrics-plus/Providers.js
+++ b/CustomApps/lyrics-plus/Providers.js
@@ -127,14 +127,11 @@ const Providers = {
 		const translation = ProviderNetease.getTranslation(list);
 		if ((synced || unsynced) && Array.isArray(translation)) {
 			const baseLyrics = synced ?? unsynced;
-			result.neteaseTranslation = baseLyrics.map((line, index) => {
-				const translatedItem = translation[index];
-				return {
-					...line,
-					text: translatedItem && typeof translatedItem.text === "string" ? translatedItem.text : line.text,
-					originalText: line.text,
-				};
-			});
+			result.neteaseTranslation = baseLyrics.map((line) => ({
+				...line,
+				text: translation.find((t) => t.startTime === line.startTime)?.text ?? line.text,
+				originalText: line.text,
+			}));
 		}
 
 		return result;

--- a/CustomApps/lyrics-plus/Providers.js
+++ b/CustomApps/lyrics-plus/Providers.js
@@ -125,8 +125,16 @@ const Providers = {
 			result.unsynced = unsynced;
 		}
 		const translation = ProviderNetease.getTranslation(list);
-		if (translation) {
-			result.neteaseTranslation = translation;
+		if ((synced || unsynced) && Array.isArray(translation)) {
+			const baseLyrics = synced ?? unsynced;
+			result.neteaseTranslation = baseLyrics.map((line, index) => {
+				const translatedItem = translation[index];
+				return {
+					...line,
+					text: translatedItem && typeof translatedItem.text === "string" ? translatedItem.text : line.text,
+					originalText: line.text,
+				};
+			});
 		}
 
 		return result;


### PR DESCRIPTION
The initial implementation by Netease only displayed a single line of translated text. This change allows for the display of two lines of lyrics, similar to Musixmatch.

![图片](https://github.com/user-attachments/assets/1ea42a1d-af90-47ce-98b5-bf1788368922)
