### PR TITLE
fix(wrapper): fix submenu not respecting items shouldAdd function

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1745,14 +1745,13 @@ Spicetify.ContextMenuV2 = (() => {
 	}
 
 	class ItemSubMenu {
-		static itemsToComponents = (items) => items.map((item) => item._element);
-
-		constructor({ text, disabled = false, leadingIcon, divider, items, shouldAdd = () => true }) {
+		constructor({ text, disabled = false, leadingIcon, divider, items = [], shouldAdd = () => true }) {
 			this.shouldAdd = shouldAdd;
 
 			this._text = text;
 			this._disabled = disabled;
 			this._leadingIcon = leadingIcon;
+			this._divider = divider;
 			this._items = items;
 			this._element = Spicetify.ReactJSX.jsx(() => {
 				const [_text, setText] = Spicetify.React.useState(this._text);
@@ -1760,6 +1759,12 @@ Spicetify.ContextMenuV2 = (() => {
 				const [_leadingIcon, setLeadingIcon] = Spicetify.React.useState(this._leadingIcon);
 				const [_divider, setDivider] = Spicetify.React.useState(this._divider);
 				const [_items, setItems] = Spicetify.React.useState(this._items);
+
+				const context = Spicetify.React.useContext(Spicetify.ContextMenuV2._context) ?? {};
+
+				const visibleItems = Spicetify.React.useMemo(() => {
+					return _items.filter((item) => item.shouldAdd(context.props, context.trigger, context.target)).map((item) => item._element);
+				}, [_items, context.props, context.trigger, context.target]);
 
 				Spicetify.React.useEffect(() => {
 					this._setText = setText;
@@ -1785,7 +1790,7 @@ Spicetify.ContextMenuV2 = (() => {
 					onClick: () => undefined,
 					disabled: _disabled,
 					leadingIcon: _leadingIcon && createIconComponent(_leadingIcon),
-					children: ItemSubMenu.itemsToComponents(_items),
+					children: visibleItems,
 				});
 			}, {});
 		}


### PR DESCRIPTION
Fixes issue when SubMenu ignores shouldAdd function in Item context menu. This makes it able to show individual submenu items based on context

Also added missing divider but seems like `divider: "both",` doesnt work anymore

Allows something like this to work
```
const Item1 = new Spicetify.ContextMenuV2.Item({
  children: "Item shows on Tracks",
  shouldAdd: (props) => {
    const uri = props?.uri || props?.item?.uri || props?.reference?.uri;
    const type = Spicetify.URI.from(uri)?.type;
    return type === Spicetify.URI.Type.TRACK;
  },
});

const Item2 = new Spicetify.ContextMenuV2.Item({
  children: "Item shows on Artists",
  shouldAdd: (props) => {
    const uri = props?.uri || props?.item?.uri || props?.reference?.uri;
    const type = Spicetify.URI.from(uri)?.type;
    return type === Spicetify.URI.Type.ARTIST;
  },
});

const Item3 = new Spicetify.ContextMenuV2.Item({
  children: "Item always shows",
});

const SubMenu = new Spicetify.ContextMenuV2.ItemSubMenu({
  text: "Only shows sometimes",
  divider: "before",
  items: [Item1, Item2, Item3],
  shouldAdd: (props) => {
    const uri = props?.uri || props?.item?.uri || props?.reference?.uri;
    const type = Spicetify.URI.from(uri)?.type;
    return (
      type === Spicetify.URI.Type.ARTIST ||
      type === Spicetify.URI.Type.TRACK
    );
  },
});
SubMenu.register();
```