### PR TITLE
add exploreButton to css-map

### DIFF
--- a/css-map.json
+++ b/css-map.json
@@ -159,6 +159,7 @@
 	"SruqsAzX8rUtY2isUZDF": "lyrics-lyricsContent-unsynced",
 	"E4q8ogfdWtye7YgotBlN": "main-actionBar-ActionBar",
 	"eSg4ntPU2KQLfpLGXAww": "main-actionBar-ActionBarRow",
+	"K06ol8ltPT_atXE_JjUP": "main-actionBar-exploreButton",
 	"CoLO4pdSl8LGWyVZA00t": "main-actionBarBackground-background",
 	"PkOz5g82CaoKk1J3GX0e": "main-actionBarBackground-background",
 	"GTAFfOA_w5vh_bDaGJAG": "main-actionButtons",


### PR DESCRIPTION
Added `exploreButton` to css-map as requested in https://github.com/spicetify/marketplace/pull/937.
I'll update the other PR once this gets merged.