### PR TITLE
feat(keyboardShortcut): change scroll top keybind

### DIFF
--- a/Extensions/keyboardShortcut.js
+++ b/Extensions/keyboardShortcut.js
@@ -40,8 +40,8 @@
 		j: { callback: () => createScrollCallback(SCROLL_STEP) },
 		k: { callback: () => createScrollCallback(-SCROLL_STEP) },
 
-		// Scroll to the top ('g') or bottom ('Shift+g') of the page
-		g: { callback: () => scrollToPosition(0) },
+		// Scroll to the top ('gg') or bottom ('Shift+g') of the page
+		"g g": { callback: () => scrollToPosition(0) },
 		"shift+g": { callback: () => scrollToPosition(1) },
 
 		// Shift + H and Shift + L to go back and forward page


### PR DESCRIPTION

This PR updates the keyboard shortcut for scrolling to the top of the page to follow Vim conventions more closely. Instead of using a single `g` key, users now need to press `gg` in sequence (like in Vim) to scroll to the top. This avoids accidental triggers and improves consistency with typical Vim keybindings.