### PR TITLE
Fix error with Spicetify.ReactJSX being undefined when laoding autoSkipExplicit.js

### DIFF
--- a/Extensions/autoSkipExplicit.js
+++ b/Extensions/autoSkipExplicit.js
@@ -5,7 +5,7 @@
 /// <reference path="../globals.d.ts" />
 
 (function ChristianSpotify() {
-	if (!Spicetify.LocalStorage) {
+	if (!Spicetify.LocalStorage || !Spicetify.ReactJSX?.jsx) {
 		setTimeout(ChristianSpotify, 1000);
 		return;
 	}


### PR DESCRIPTION
There should be a better way to do this but this is sort of a "hot fix".