### PR TITLE
fix(globals): add isRight property to Button class

### DIFF
--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1814,11 +1814,12 @@ declare namespace Spicetify {
 	 */
 	namespace Topbar {
 		class Button {
-			constructor(label: string, icon: Icon | string, onClick: (self: Button) => void, disabled?: boolean);
+			constructor(label: string, icon: Icon | string, onClick: (self: Button) => void, disabled?: boolean, isRight?: boolean);
 			label: string;
 			icon: string;
 			onClick: (self: Button) => void;
 			disabled: boolean;
+			isRight: boolean;
 			element: HTMLButtonElement;
 			tippy: any;
 		}


### PR DESCRIPTION
Seemed like an oversight to me but I'd like to hear your feedback on this. I have not checked other classes for outdated types.