### PR TITLE
feat(wrapper): allow nesting submenus

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1749,7 +1749,7 @@ Spicetify.ContextMenuV2 = (() => {
 			return items.filter((item) => (item.shouldAdd || (() => true))?.(props, trigger, target)).map((item) => item._element);
 		};
 
-		constructor({ text, disabled = false, leadingIcon, divider, items, shouldAdd = () => true }) {
+		constructor({ text, disabled = false, leadingIcon, divider, items, depth = 1, shouldAdd = () => true }) {
 			this.shouldAdd = shouldAdd;
 
 			this._text = text;
@@ -1757,12 +1757,14 @@ Spicetify.ContextMenuV2 = (() => {
 			this._leadingIcon = leadingIcon;
 			this._divider = divider;
 			this._items = items;
+			this._depth = depth;
 			this._element = Spicetify.ReactJSX.jsx(() => {
 				const [_text, setText] = Spicetify.React.useState(this._text);
 				const [_disabled, setDisabled] = Spicetify.React.useState(this._disabled);
 				const [_leadingIcon, setLeadingIcon] = Spicetify.React.useState(this._leadingIcon);
 				const [_divider, setDivider] = Spicetify.React.useState(this._divider);
 				const [_items, setItems] = Spicetify.React.useState(this._items);
+				const [_depth, setDepth] = Spicetify.React.useState(this._depth);
 
 				Spicetify.React.useEffect(() => {
 					this._setText = setText;
@@ -1770,12 +1772,14 @@ Spicetify.ContextMenuV2 = (() => {
 					this._setLeadingIcon = setLeadingIcon;
 					this._setDivider = setDivider;
 					this._setItems = setItems;
+					this._setDepth = setDepth;
 					return () => {
 						this._setText = undefined;
 						this._setDisabled = undefined;
 						this._setLeadingIcon = undefined;
 						this._setDivider = undefined;
 						this._setItems = undefined;
+						this._setDepth = undefined;
 					};
 				});
 
@@ -1785,7 +1789,7 @@ Spicetify.ContextMenuV2 = (() => {
 				return Spicetify.React.createElement(Spicetify.ReactComponent.MenuSubMenuItem, {
 					displayText: _text,
 					divider: _divider,
-					depth: 1,
+					depth: _depth,
 					placement: "right-start",
 					onOpenChange: () => undefined,
 					onClick: () => undefined,


### PR DESCRIPTION
Used to be hardcoded to 1 causing the nested submenu to disappear when hovered.

Allows this to work

<img width="652" height="225" alt="Screenshot 2025-09-13 213055" src="https://github.com/user-attachments/assets/190e2a9f-36e1-4904-bd6d-ccd23537b440" />

To use add the depth and then 1+ the previous

```js
const test1 = new Spicetify.ContextMenuV2.Item({
  children: "test1",
  onClick: async () => {
    console.log("test1");
  },
  shouldAdd: () => true,
});

const NestedSubMenu = new Spicetify.ContextMenuV2.ItemSubMenu({
  text: "NestedSubMenu",
  depth: 2,
  items: [test1],
  shouldAdd: () => true,
});

const SubMenu = new Spicetify.ContextMenuV2.ItemSubMenu({
  text: "SubMenu",
  // depth: 1, This is the default
  items: [
    NestedSubMenu,
  ],
  shouldAdd: () => true,
}).register();
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multi-level nested submenus in context menus.
  * Submenus now display their correct nesting level dynamically.
  * Enables deeper, more organized navigation for complex actions.
  * Improves clarity and discoverability within context menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->