### PR TITLE
fix: update spicetifyWrapper.js

### DIFF
--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1011,6 +1011,8 @@ applyScrollingFix();
 		Spicetify.URI.from = Object.values(URIModules.find(a => Object.values(a).some(v => typeof v === 'function' && v.toString().includes("allowedTypes")))).find(v => typeof v === 'function' && v.toString().includes("allowedTypes"));
 		Spicetify.URI.fromString = Object.values(URIModules.find(a => Object.values(a).some(v => typeof v === 'function' && v.toString().includes("Argument `uri`")))).find(v => typeof v === 'function' && v.toString().includes("Argument `uri`"));
 
+
+		
 		// createURI functions
 		const createURIFunctions = URIModules.filter((m) => typeof m === "function" && m.toString().match(/\([\w$]+\./));
 		for (const type of Object.keys(Spicetify.URI.Type)) {

--- a/jsHelper/spicetifyWrapper.js
+++ b/jsHelper/spicetifyWrapper.js
@@ -1008,8 +1008,8 @@ applyScrollingFix();
 		Spicetify.URI.Type = URIModules.find((m) => m?.PLAYLIST_V2);
 
 		// Parse functions
-		Spicetify.URI.from = URIModules.find((m) => typeof m === "function" && m.toString().includes("allowedTypes"));
-		Spicetify.URI.fromString = URIModules.find((m) => typeof m === "function" && m.toString().includes("Argument `uri`"));
+		Spicetify.URI.from = Object.values(URIModules.find(a => Object.values(a).some(v => typeof v === 'function' && v.toString().includes("allowedTypes")))).find(v => typeof v === 'function' && v.toString().includes("allowedTypes"));
+		Spicetify.URI.fromString = Object.values(URIModules.find(a => Object.values(a).some(v => typeof v === 'function' && v.toString().includes("Argument `uri`")))).find(v => typeof v === 'function' && v.toString().includes("Argument `uri`"));
 
 		// createURI functions
 		const createURIFunctions = URIModules.filter((m) => typeof m === "function" && m.toString().match(/\([\w$]+\./));


### PR DESCRIPTION
fixed URI.fromString and URI.from functions 

new update of spotify had them weirdly nested in objects

this was breaking [spicetify-visualizer](https://github.com/Konsl/spicetify-visualizer/tree/main) app 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability of URI handling to reduce errors when parsing or opening Spotify links.
  - Increased compatibility across app versions by making URI detection more robust to internal structure changes.
  - Mitigated edge-case failures that could previously break features relying on URIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->