### PR TITLE
fix(css-map): replace `lyrics-lyricsContent-active` key

### DIFF
--- a/css-map.json
+++ b/css-map.json
@@ -155,7 +155,7 @@
 	"SaEkeiyzAoXnWVSDiTR7": "lyrics-lyrics-vocalRemoval",
 	"arY01KDGhWNgzlAHlhpd": "lyrics-lyricsContent-active",
 	"EhKgYshvOwpSrTv399Mw": "lyrics-lyricsContent-active",
-	"F8gozO67UMCQqFoPmjyn": "lyrics-lyricsContent-active",
+	"_gZrl2ExJwyxPy1pEUG2": "lyrics-lyricsContent-active",
 	"iq4cgi0YEKr6DGaTtzUj": "lyrics-lyricsContent-description",
 	"MEjuIn9iTBQbnCqHpkoQ": "lyrics-lyricsContent-highlight",
 	"aeO5D7ulxy19q4qNBrkk": "lyrics-lyricsContent-highlight",


### PR DESCRIPTION
Previous changes introduced in [this pr](https://github.com/spicetify/cli/pull/3524); added new keys for lyrics and one of them (lyrics-lyricsContent-active) is wrong and should be changed to `_gZrl2ExJwyxPy1pEUG2`. The `F8gozO67UMCQqFoPmjyn` key is present on all lyrics containers while it should only be visible on one. 

<img width="639" height="434" alt="image" src="https://github.com/user-attachments/assets/7d920a2c-a3c6-4cc1-829c-e5c3ae444270" />

I'm not entirely sure for what this key (`F8gozO67UMCQqFoPmjyn`) was responsible in the previous version though. Right now it has only one line in css: `margin-bottom: .6em;`