### PR TITLE
docs(install): explain shell PATH activation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -146,7 +146,13 @@ esac
 
 echo
 log "spicetify v$tag was installed successfully to $spicetify_install"
-log "Run 'spicetify --help' to get started"
+if [ -n "${shellrc:-}" ] && [ -f "$shellrc" ]; then
+    log "Open a new terminal or reload your shell profile to use spicetify:"
+    log "  source \"$shellrc\""
+    log "Then run 'spicetify --help' to get started"
+else
+    log "After adding spicetify to your PATH, run 'spicetify --help' to get started"
+fi
 
 echo "Do you want to install spicetify Marketplace? (Y/n)"
 read -r choice < /dev/tty


### PR DESCRIPTION
## Summary

- tell shell-installer users to open a new terminal or reload their shell profile before using `spicetify`
- print the profile path selected by the installer, including custom `ZDOTDIR` locations
- keep the manual-PATH fallback accurate for unsupported shells

## Why

The shell installer updates a startup file, but when invoked through `curl | sh` it cannot update the already-running parent shell. The existing completion message immediately suggests running `spicetify --help`, which results in `command not found` until the user opens a new terminal or reloads the profile.

Windows is unaffected: `install.ps1` updates `$env:PATH` in the current PowerShell process as well as the persistent user PATH.

## Verification

- `sh -n install.sh`
- controlled installer smoke tests for zsh with a custom `ZDOTDIR`, bash, and fish
- Marketplace subprocess smoke test confirming the installer's exported PATH still resolves `spicetify`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation completion guidance based on whether a shell profile is detected.
  * Added profile reload instructions when applicable.
  * Provided `PATH` setup instructions when no usable shell profile is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->