### PR TITLE
feat(config): allow editing spotify launch flags

### DIFF
--- a/spicetify.go
+++ b/spicetify.go
@@ -52,8 +52,14 @@ func init() {
 	log.SetOutput(colorable.NewColorableStdout())
 
 	// Separates flags and commands
+	parseFlags := true
 	for _, v := range os.Args[1:] {
-		if len(v) > 0 && v[0] == '-' {
+		if parseFlags && v == "--" {
+			parseFlags = false
+			continue
+		}
+
+		if parseFlags && len(v) > 0 && v[0] == '-' {
 			if len(v) > 2 && v[1] != '-' {
 				for _, char := range v[1:] {
 					flags = append(flags, "-"+string(char))
@@ -494,6 +500,8 @@ upgrade|update      Update spicetify to the latest version if an update is avail
 
 --bypass-admin      Bypass admin or root (sudo) check. NOT RECOMMENDED
 
+--                  Stop parsing flags; treat remaining arguments as command values
+
 -c, --config        Print config file path and quit
 
 -h, --help          Print this help text and quit
@@ -532,6 +540,8 @@ replace_colors <0 | 1>
 spotify_launch_flags <string>
     Command-line flags used when launching/restarting Spotify.
     Separate each flag with "|".
+    To set flags from the CLI, place "--" before the value.
+    Example: spicetify config spotify_launch_flags -- "--flag-1|--flag-2"
     List of valid flags: https://spicetify.app/docs/development/spotify-cli-flags
 
 always_enable_devtools <0 | 1>

--- a/src/cmd/config.go
+++ b/src/cmd/config.go
@@ -20,9 +20,7 @@ func EditConfig(args []string) {
 		switch field {
 		case "extensions", "custom_apps":
 			arrayType(featureSection, field, value)
-		case "spotify_launch_flags":
-			// not editable via config command
-		case "prefs_path", "spotify_path", "current_theme", "color_scheme":
+		case "prefs_path", "spotify_path", "current_theme", "color_scheme", "spotify_launch_flags":
 			stringType(settingSection, field, value)
 
 		default:


### PR DESCRIPTION
## Summary

- recognize `--` as the standard end-of-options separator
- allow `spicetify config` to update `spotify_launch_flags`
- document the CLI syntax in the general and config help output

## Why

`spotify_launch_flags` is displayed by the config command and consumed whenever Spicetify starts Spotify, but `EditConfig` intentionally ignored attempts to update it. Values normally begin with `-`, so the existing argument parser classified them as Spicetify flags before the config command could read them.

Using the conventional `--` separator keeps existing parsing unchanged while allowing the value to reach the existing string-setting path:

```console
spicetify config spotify_launch_flags -- "--flag-1|--flag-2"
```

## Testing

- `go test ./...`
- `go vet ./...`
- `go build`
- `node scripts/build-wrapper.mjs --check`
- isolated CLI check confirming a pipe-separated flag value is saved and read back unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for `--` to mark the end of command-line flags, allowing dash-prefixed command values.
  - Made `spotify_launch_flags` editable through configuration settings.
  - Added usage guidance and an example for configuring Spotify launch flags.

- **Documentation**
  - Updated command-line help to explain the `--` separator behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->