### PR TITLE
feat(lyrics-plus): add karaoke mode for lrclib

### DIFF
--- a/CustomApps/lyrics-plus/ProviderLRCLIB.js
+++ b/CustomApps/lyrics-plus/ProviderLRCLIB.js
@@ -9,11 +9,27 @@ const ProviderLRCLIB = (() => {
 			duration: durr,
 		};
 
-		const finalURL = `${baseURL}?${Object.keys(params)
-			.map((key) => `${key}=${encodeURIComponent(params[key])}`)
+		const getURL = (queryParams) => `${baseURL}?${Object.keys(queryParams)
+			.map((key) => `${key}=${encodeURIComponent(queryParams[key])}`)
 			.join("&")}`;
+		const headers = {
+			"x-user-agent": `spicetify v${Spicetify.Config.version} (https://github.com/spicetify/cli)`,
+		};
 
-		const body = await fetch(finalURL, {
+		let body;
+		try {
+			body = await fetch(getURL(params), { headers });
+		} catch {
+			body = null;
+		}
+
+		if (body?.status === 200) {
+			return await body.json();
+		}
+
+		const fallbackParams = { ...params };
+		delete fallbackParams.duration;
+		body = await fetch(getURL(fallbackParams), {
 			headers: {
 				"x-user-agent": `spicetify v${Spicetify.Config.version} (https://github.com/spicetify/cli)`,
 			},
@@ -39,6 +55,61 @@ const ProviderLRCLIB = (() => {
 		return Utils.parseLocalLyrics(unsyncedLyrics).unsynced;
 	}
 
+	function getKaraoke(body) {
+		const lyricsFile = body?.lyricsfile;
+		if (typeof lyricsFile !== "string") return null;
+
+		const result = [];
+		let line;
+		let word;
+
+		function parseValue(value) {
+			const trimmed = value.trim();
+			if ((trimmed.startsWith("'") && trimmed.endsWith("'")) || (trimmed.startsWith('"') && trimmed.endsWith('"'))) {
+				return trimmed.slice(1, -1).replaceAll("''", "'");
+			}
+			return trimmed;
+		}
+
+		function finishWord() {
+			if (!line || !word || word.text === undefined || word.start_ms === undefined || word.end_ms === undefined) return;
+			line.words.push({ word: word.text, time: Math.max(word.end_ms - word.start_ms, 0) });
+			word = null;
+		}
+
+		function finishLine() {
+			finishWord();
+			if (line && line.start_ms !== undefined && line.words.length) {
+				result.push({ startTime: line.start_ms, text: line.words });
+			}
+			line = null;
+		}
+
+		for (const rawLine of lyricsFile.split(/\r?\n/)) {
+			const indentation = rawLine.match(/^\s*/)[0].length;
+			const content = rawLine.trim();
+			if (indentation === 2 && content.startsWith("- text:")) {
+				finishLine();
+				line = { start_ms: undefined, words: [] };
+				continue;
+			}
+			if (indentation === 6 && content.startsWith("- text:")) {
+				finishWord();
+				word = { text: parseValue(content.slice("- text:".length)) };
+				continue;
+			}
+			const timestamp = content.match(/^start_ms:\s*(\d+(?:\.\d+)?)/) || content.match(/^end_ms:\s*(\d+(?:\.\d+)?)/);
+			if (timestamp) {
+				const key = content.startsWith("start_ms:") ? "start_ms" : "end_ms";
+				if (word) word[key] = Number(timestamp[1]);
+				else if (line) line[key] = Number(timestamp[1]);
+			}
+		}
+		finishLine();
+
+		return result.length ? result : null;
+	}
+
 	function getSynced(body) {
 		const syncedLyrics = body?.syncedLyrics;
 		const isInstrumental = body.instrumental;
@@ -49,5 +120,5 @@ const ProviderLRCLIB = (() => {
 		return Utils.parseLocalLyrics(syncedLyrics).synced;
 	}
 
-	return { findLyrics, getSynced, getUnsynced };
+	return { findLyrics, getKaraoke, getSynced, getUnsynced };
 })();

--- a/CustomApps/lyrics-plus/ProviderLRCLIB.js
+++ b/CustomApps/lyrics-plus/ProviderLRCLIB.js
@@ -72,15 +72,20 @@ const ProviderLRCLIB = (() => {
 		}
 
 		function finishWord() {
-			if (!line || !word || word.text === undefined || word.start_ms === undefined || word.end_ms === undefined) return;
-			line.words.push({ word: word.text, time: Math.max(word.end_ms - word.start_ms, 0) });
+			if (!line || !word || word.text === undefined || word.start_ms === undefined) return;
+			line.words.push({ word: word.text, start_ms: word.start_ms, end_ms: word.end_ms });
 			word = null;
 		}
 
 		function finishLine() {
 			finishWord();
 			if (line && line.start_ms !== undefined && line.words.length) {
-				result.push({ startTime: line.start_ms, text: line.words });
+				const words = line.words.map((currentWord, index) => {
+					const nextWord = line.words[index + 1];
+					const end = currentWord.end_ms ?? nextWord?.start_ms ?? line.end_ms ?? currentWord.start_ms;
+					return { word: currentWord.word, time: Math.max(end - currentWord.start_ms, 0) };
+				});
+				result.push({ startTime: line.start_ms, text: words });
 			}
 			line = null;
 		}
@@ -98,11 +103,12 @@ const ProviderLRCLIB = (() => {
 				word = { text: parseValue(content.slice("- text:".length)) };
 				continue;
 			}
-			const timestamp = content.match(/^start_ms:\s*(\d+(?:\.\d+)?)/) || content.match(/^end_ms:\s*(\d+(?:\.\d+)?)/);
+			const timestamp = content.match(/^(start_ms|end_ms):\s*(\d+(?:\.\d+)?)/);
 			if (timestamp) {
-				const key = content.startsWith("start_ms:") ? "start_ms" : "end_ms";
-				if (word) word[key] = Number(timestamp[1]);
-				else if (line) line[key] = Number(timestamp[1]);
+				const key = timestamp[1];
+				const value = Number(timestamp[2]);
+				if (indentation >= 6 && word) word[key] = value;
+				else if (line) line[key] = value;
 			}
 		}
 		finishLine();

--- a/CustomApps/lyrics-plus/Providers.js
+++ b/CustomApps/lyrics-plus/Providers.js
@@ -183,6 +183,11 @@ const Providers = {
 			return result;
 		}
 
+		const karaoke = ProviderLRCLIB.getKaraoke(list);
+		if (karaoke) {
+			result.karaoke = karaoke;
+		}
+
 		const synced = ProviderLRCLIB.getSynced(list);
 		if (synced) {
 			result.synced = synced;

--- a/CustomApps/lyrics-plus/index.js
+++ b/CustomApps/lyrics-plus/index.js
@@ -72,8 +72,8 @@ const CONFIG = {
 	providers: {
 		lrclib: {
 			on: getConfig("lyrics-plus:provider:lrclib:on"),
-			desc: "Lyrics sourced from lrclib.net. Supports both synced and unsynced lyrics. LRCLIB is a free and open-source lyrics provider.",
-			modes: [SYNCED, UNSYNCED],
+			desc: "Lyrics sourced from lrclib.net. Supports karaoke, synced and unsynced lyrics. LRCLIB is a free and open-source lyrics provider.",
+			modes: [KARAOKE, SYNCED, UNSYNCED],
 		},
 		musixmatch: {
 			on: getConfig("lyrics-plus:provider:musixmatch:on"),


### PR DESCRIPTION
LRCLIB now supports karaoke lyrics with their API (https://lrclib.net/lyricsfile)

Also i made a little change to how lyrics-plus gets lyrics from LRCLIB. I made that when a request to LRCLIB fails, it removes the timestamps from the request, becouse if some lyrics from LRCLIB have a wrong timestamp, even 1 second, lyrics-plus will not display the lyrics.


example of song with karaoke lyrics:
https://open.spotify.com/track/294IHntvpddOtVQremPRIg

Image of said song with karaoke lyrics:
<img width="1197" height="854" alt="imagem" src="https://github.com/user-attachments/assets/01d4d836-0778-49df-95b1-9bcf4dbe1dfe" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added karaoke lyrics support for LRCLIB results.
  * Karaoke lyrics include synchronized words aligned with timestamps.
  * LRCLIB supports synced, unsynced, and karaoke lyric modes.

* **Bug Fixes**
  * Improved lyric retrieval reliability with automatic retries when requests fail or duration details are unavailable.
  * Improved karaoke timing by deriving missing word durations from nearby timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->