### PR TITLE
fix(wrapper): update `Color.CSSFormat` module check

### DIFF
--- a/src/jsHelper/spicetifyWrapper/webpack/runtime-resolvers.js
+++ b/src/jsHelper/spicetifyWrapper/webpack/runtime-resolvers.js
@@ -127,7 +127,7 @@ export function exposeRuntimeResolvers({ cache, chunks, modules, functionModules
     Spicetify.ReactQuery.useInfiniteQuery = Object.values(require(infiniteQueryChunk[0])).find((m) => typeof m === "function");
   }
 
-  if (Spicetify.Color) Spicetify.Color.CSSFormat = modules.find((m) => m?.RGBA);
+  if (Spicetify.Color) Spicetify.Color.CSSFormat = modules.find((m) => typeof m?.RGBA === "number");
 
   // Combine snackbar and notification
   (function bindShowNotification(attempt = 0) {


### PR DESCRIPTION
The current filter matches two modules (and selects the first, wrong, one):
<img width="805" height="116" alt="image" src="https://github.com/user-attachments/assets/844ddf5e-679b-4520-87bc-9c58f8bcc5f0" />

The other module is a Proxy object with a get handler that returns some value for whatever property you try to access on it.
Therefore, you can't just test more entries of the CSSFormat enum, but since the Proxy object always returns some sort of React component, we can just check for the type of the returned value.

In my testing (Spotify version 1.2.95.453.g0eeebbed), this correctly identified the CSSFormat module:
<img width="798" height="135" alt="image" src="https://github.com/user-attachments/assets/3dc2a5fc-55b2-49ac-b1c8-c19581f6d65e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved color handling by reliably identifying valid color formatting data.
  * Prevented incorrect color module detection that could affect visual styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->