### PR TITLE
feat: spicetify-live-reload

### DIFF
--- a/spicetify.go
+++ b/spicetify.go
@@ -349,6 +349,9 @@ func main() {
 		case "restart":
 			cmd.SpotifyRestart()
 
+		case "reload":
+			cmd.Reload()
+
 		case "auto":
 			cmd.Auto(version)
 			shouldRestart = true
@@ -395,6 +398,12 @@ watch               Enter watch mode.
 
 
 restart             Restart Spotify client.
+
+reload              Push the active theme's colors/CSS (and JS/assets if enabled)
+                    into an already-running Spotify client without restarting it,
+                    so the window stays open and playback keeps running.
+                    The first run needs one restart to enable a live connection;
+                    every run after that updates colors live, no restart needed.
 
 ` + utils.Bold("NON-CHAINABLE COMMANDS") + `
 spotify-updates     Block Spotify updates by patching spotify executable.

--- a/src/cmd/reload.go
+++ b/src/cmd/reload.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"os"
+	"time"
+
+	"github.com/spicetify/cli/src/utils"
+)
+
+// Reload updates the current theme's colors/CSS/JS/assets and pushes the
+// change into an already-running Spotify client over the Chrome DevTools
+// Protocol, without killing the Spotify process. This keeps the window open
+// and playback running, unlike "apply" or "restart".
+//
+// The very first time it runs against a Spotify instance that wasn't
+// started with remote debugging enabled, one restart is unavoidable to open
+// that connection. Every following call reuses it and never restarts again,
+// as long as Spotify keeps running (or is relaunched with the same flags,
+// e.g. via "spotify_launch_flags" in the spicetify config).
+func Reload() {
+	if !isValidForWatching() {
+		os.Exit(1)
+	}
+
+	CheckStates()
+	InitSetting()
+
+	refreshThemeCSS()
+	if injectJS {
+		refreshThemeJS()
+	}
+	if overwriteAssets {
+		refreshThemeAssets()
+	}
+
+	debuggerURL := utils.GetDebuggerPath()
+	if len(debuggerURL) == 0 {
+		utils.PrintInfo("No live connection to Spotify found. Enabling DevTools and restarting once to set it up...")
+		EnableDevTools()
+		SpotifyRestart("--remote-debugging-port=9222", "--remote-allow-origins=*")
+
+		for len(debuggerURL) == 0 {
+			time.Sleep(100 * time.Millisecond)
+			debuggerURL = utils.GetDebuggerPath()
+		}
+
+		utils.PrintSuccess("Applied theme. Spotify is now set up for live reload; run this command again next time to update colors without restarting.")
+		return
+	}
+
+	if err := utils.SendCSSReload(&debuggerURL); err != nil {
+		utils.PrintError("Could not live-reload Spotify: " + err.Error())
+		utils.PrintInfo(`Run "spicetify restart" to apply changes manually`)
+		os.Exit(1)
+	}
+
+	utils.PrintSuccess("Reloaded theme colors without restarting Spotify")
+}

--- a/src/cmd/watch.go
+++ b/src/cmd/watch.go
@@ -225,7 +225,7 @@ func isValidForWatching() bool {
 	status := spotifystatus.Get(appDestPath)
 
 	if !status.IsModdable() {
-		utils.PrintError(`You haven't applied. Run "spicetify apply" once before entering watch mode`)
+		utils.PrintError(`You haven't applied. Run "spicetify apply" once first`)
 		return false
 	}
 

--- a/src/utils/watcher.go
+++ b/src/utils/watcher.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"os"
@@ -131,6 +132,55 @@ func SendReload(debuggerURL *string) error {
 	defer socket.Close()
 
 	if _, err := socket.Write([]byte(`{"id":0,"method":"Runtime.evaluate","params":{"expression":"window.location.reload()"}}`)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// cssHotSwapExpression re-fetches the theme's "colors.css" and "user.css"
+// stylesheet links (tagged with class "userCSS", see src/preprocess) by
+// bumping a cache-busting query param, instead of reloading the whole page.
+// This updates colors/CSS in place without resetting app state (e.g. playback).
+const cssHotSwapExpression = `(() => {
+	var bust = Date.now();
+	var links = document.querySelectorAll("link.userCSS");
+	links.forEach(function (link) {
+		var url = new URL(link.href, window.location.href);
+		url.searchParams.set("spicetify_reload", bust);
+		link.href = url.toString();
+	});
+	return links.length;
+})()`
+
+// SendCSSReload sends a command to the debugger Websocket server that
+// hot-swaps the theme's stylesheet links without reloading the page,
+// so Spotify's playback and window state are left untouched.
+func SendCSSReload(debuggerURL *string) error {
+	if len(*debuggerURL) == 0 {
+		*debuggerURL = GetDebuggerPath()
+	}
+
+	if len(*debuggerURL) == 0 {
+		return errors.New("no debugger connection to Spotify found")
+	}
+
+	socket, err := websocket.Dial(*debuggerURL, "", "http://localhost/")
+	if err != nil {
+		return err
+	}
+	defer socket.Close()
+
+	payload, err := json.Marshal(map[string]any{
+		"id":     0,
+		"method": "Runtime.evaluate",
+		"params": map[string]string{"expression": cssHotSwapExpression},
+	})
+	if err != nil {
+		return err
+	}
+
+	if _, err := socket.Write(payload); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
# Spicetify-live-reload 
## What this does


Adds a new `spicetify reload` command that pushes the active theme's
colors/CSS (and optionally JS/assets) into an already-running Spotify
client, without killing the process. This keeps the window open and
playback running, unlike `apply` or `restart`.

## How it works

- First run: if there's no existing live connection (DevTools) to
  Spotify, `reload` enables DevTools and restarts Spotify once with
  `--remote-debugging-port=9222 --remote-allow-origins=*` to open a
  Chrome DevTools Protocol connection.
- Every run after that: `reload` re-applies the theme's CSS (and JS/
  assets if enabled), then sends a `Runtime.evaluate` command over the
  existing CDP WebSocket that bumps a cache-busting query param on the
  `link.userCSS` stylesheet links, causing the browser to refetch just
  those stylesheets. The rest of the app state (playback, current
  view, etc.) is left untouched.

## Files changed

- `spicetify.go`: registers the `reload` command and its help text.
- `src/cmd/reload.go` (new): the `Reload()` command implementation.
- `src/utils/watcher.go`: adds `SendCSSReload`, which sends the
  CDP command to hot-swap the theme stylesheets.
- `src/cmd/watch.go`: minor wording tweak to an existing error message.

## Testing

- Tested locally with `spicetify apply` then `spicetify reload` on a
  running Spotify client; colors updated without a restart.
- Verified the first-run path (DevTools not yet enabled) triggers a
  single restart and subsequent runs no longer restart.
- A video to watch it work on youtube : https://youtu.be/nYZ6cWBquTI 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `reload` command to update the active theme’s colors and CSS in a running Spotify client without restarting it.
  * Supports refreshing JavaScript and assets when enabled.
  * Automatically guides initial setup of the live-reload connection.

* **Bug Fixes**
  * Improved guidance when watch mode is unavailable, including instructions to apply the theme first.
  * Added clearer recovery messaging when live reloading cannot connect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->