### PR TITLE
feat(lyrics-plus): optimize musixmatch API calls

### DIFF
--- a/CustomApps/lyrics-plus/ProviderMusixmatch.js
+++ b/CustomApps/lyrics-plus/ProviderMusixmatch.js
@@ -55,6 +55,8 @@ const ProviderMusixmatch = (() => {
 			q_duration: durr,
 			f_subtitle_length: Math.floor(durr),
 			usertoken: CONFIG.providers.musixmatch.token,
+			optional_calls: "track.richsync",
+			richsync_compact_type: "words",
 			part: "track_lyrics_translation_status,track_structure,track_performer_tagging",
 		};
 
@@ -231,28 +233,12 @@ const ProviderMusixmatch = (() => {
 			return null;
 		}
 
-		const baseURL = "https://apic-appmobile.musixmatch.com/ws/1.1/track.richsync.get?format=json&subtitle_format=mxm&app_id=mac-ios-v2.0&";
-
-		const params = {
-			f_subtitle_length: meta.track.track_length,
-			q_duration: meta.track.track_length,
-			commontrack_id: meta.track.commontrack_id,
-			usertoken: CONFIG.providers.musixmatch.token,
-		};
-
-		const finalURL =
-			baseURL +
-			Object.keys(params)
-				.map((key) => `${key}=${encodeURIComponent(params[key])}`)
-				.join("&");
-
-		let result = await Spicetify.CosmosAsync.get(finalURL, null, headers);
-
-		if (result.message.header.status_code !== 200) {
+		const richsyncCall = body?.["track.richsync.get"];
+		if (!richsyncCall || richsyncCall.message.header.status_code !== 200 || !richsyncCall.message.body.richsync) {
 			return null;
 		}
 
-		result = result.message.body;
+		const result = richsyncCall.message.body;
 
 		const snippetQueue = parsePerformerData(meta);
 


### PR DESCRIPTION
Optimizes the Musixmatch API calls in the `lyrics-plus` custom app by preventing redundant network requests when syncing karaoke lyrics. Previously, `findLyrics` would call `macro.subtitles.get`, and if karaoke syncing was needed, `getKaraoke` would make a separate follow-up call to `track.richsync.get`.

By appending `track.richsync` as an optional call to the initial `macro.subtitles.get` parameter, `getKaraoke` can now extract the richsync payload directly from the combined response body. This eliminates the need for a separate `Spicetify.CosmosAsync.get` request, effectively cutting network calls in half to improve load times and reduce traffic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved lyric timing retrieval for more compact karaoke synchronization data.

* **Bug Fixes**
  * Karaoke parsing now handles unavailable or unsuccessful synchronization responses gracefully.
  * Eliminated an unnecessary follow-up request when synchronization data is already available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->