### PR TITLE
fix: allow running as administrator and patch path/version bugs

### DIFF
--- a/spicetify.go
+++ b/spicetify.go
@@ -121,12 +121,14 @@ func init() {
 		pterm.DisableOutput()
 	}
 
+	// Running as administrator/root is discouraged because Spotify normally
+	// runs as a normal user and may be unable to read files written with admin
+	// privileges (resulting in a black/blank window). We no longer hard-fail on
+	// this: instead we warn and continue so spicetify can be installed/run from
+	// an elevated shell. Pass --bypass-admin to suppress the warning entirely.
 	if isAdmin.Check(bypassAdminCheck) {
-		utils.PrintError("Spicetify should NOT be run with administrator or root privileges")
-		utils.PrintError("Doing so can cause Spotify to show a black/blank window after applying!")
-		utils.PrintError("This happens because Spotify (running as a normal user) can't access files modified with admin privileges")
-		utils.PrintInfo("If you understand the risks and need to continue, you can use the '--bypass-admin' flag.")
-		os.Exit(1)
+		utils.PrintWarning("Running as administrator/root is not recommended: Spotify (running as a normal user) may be unable to access files modified with admin privileges, which can cause a black/blank window after applying.")
+		utils.PrintInfo("Continuing anyway. If you hit a blank window, re-install Spotify and run spicetify from a normal (non-admin) user, or pass '--bypass-admin' to silence this warning.")
 	}
 
 	for i, flag := range flags {

--- a/src/preprocess/preprocess.go
+++ b/src/preprocess/preprocess.go
@@ -1097,6 +1097,9 @@ type githubRelease = utils.GithubRelease
 
 func splitVersion(version string) ([3]int, error) {
 	vstring := version
+	if len(vstring) == 0 {
+		return [3]int{}, errors.New("invalid version string")
+	}
 	if vstring[0:1] == "v" {
 		vstring = version[1:]
 	}

--- a/src/utils/config.go
+++ b/src/utils/config.go
@@ -317,7 +317,7 @@ func linuxApp() string {
 		_, err := os.Stat(filepath.Join(ReplaceEnvVarsInString(v), "Apps"))
 		_, err2 := os.Stat(filepath.Join(ReplaceEnvVarsInString(v), "spotify"))
 		if err == nil && err2 == nil {
-			return v
+			return ReplaceEnvVarsInString(v)
 		}
 	}
 

--- a/src/utils/utils.go
+++ b/src/utils/utils.go
@@ -62,7 +62,6 @@ func Unzip(src, dest string) error {
 			err = os.MkdirAll(fdir, 0700)
 			if err != nil {
 				log.Fatal(err)
-				return err
 			}
 			f, err := os.OpenFile(
 				fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0700)


### PR DESCRIPTION
## Summary
- Allow spicetify to run/install under administrator or root **without exiting**. Previously it hard-failed with `os.Exit(1)`; now it only warns and continues (Spotify normally runs as a normal user). `--bypass-admin` still silences the warning.
- Fix Linux Spotify path detection: flatpak/launcher candidate paths containing `$HOME` were returned as raw literals without env expansion, so detection failed. Now returns the env-resolved path (`src/utils/config.go`).
- Guard `splitVersion` against an empty version string to avoid an index-out-of-range panic (`src/preprocess/preprocess.go`).
- Remove an unreachable `return err` after `log.Fatal` in `Unzip` (`src/utils/utils.go`).

## Test plan
- `go build ./...` and `go vet ./...` pass.
- Built binary and ran it elevated (RunAs administrator): now prints a warning and continues (exit 0) instead of failing.

Co-Authored-By: ahkurdev <ah.kurniawan27@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Spicetify now continues running from administrator or root shells, with warnings that can be suppressed using the bypass option.
  - Invalid or empty version strings now return a clear error instead of causing a crash.
  - Linux Spotify installation paths now correctly expand environment variables.
  - Archive extraction failures now stop execution immediately with an error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->