### PR TITLE
fix(tui): render for smaller terminals

### DIFF
--- a/rust/crates/tui/src/app/input.rs
+++ b/rust/crates/tui/src/app/input.rs
@@ -58,6 +58,9 @@ impl TuiApp {
 
     pub(crate) fn handle_mouse(&mut self, mouse: crossterm::event::MouseEvent) {
         self.layout.mouse_pos = (mouse.column, mouse.row);
+        if !self.layout.mouse_interactions_enabled() {
+            return;
+        }
 
         if self.confirm_quit_open {
             if let MouseEventKind::Up(MouseButton::Left) = mouse.kind {
@@ -192,5 +195,43 @@ impl TuiApp {
 
     pub(crate) fn mouse_in_log(&self, col: u16, row: u16) -> bool {
         self.layout.log_rect.is_some_and(|r| r.contains(Position::new(col, row)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crossterm::event::{KeyModifiers, MouseEvent};
+
+    use super::*;
+    use crate::app::{InputState, Page, test_app};
+
+    fn mouse(kind: MouseEventKind) -> MouseEvent {
+        MouseEvent { kind, column: 3, row: 4, modifiers: KeyModifiers::NONE }
+    }
+
+    #[tokio::test]
+    async fn disabled_mouse_interactions_preserve_hidden_state() {
+        let mut app = test_app();
+        app.layout.clear_interaction_regions();
+        app.input = Some(InputState {
+            action: MenuAction::PkgDelete,
+            buffer: "module-id".to_string(),
+            step: InputStep::ModuleId,
+        });
+
+        app.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left)));
+
+        assert_eq!(app.layout.mouse_pos, (3, 4));
+        assert_eq!(app.input.as_ref().map(|input| input.buffer.as_str()), Some("module-id"));
+
+        app.input = None;
+        app.confirm_quit_open = true;
+        app.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left)));
+        assert!(app.confirm_quit_open);
+
+        app.confirm_quit_open = false;
+        app.menu.page = Page::Category(0);
+        app.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Right)));
+        assert_eq!(app.menu.page, Page::Category(0));
     }
 }

--- a/rust/crates/tui/src/app/mod.rs
+++ b/rust/crates/tui/src/app/mod.rs
@@ -120,7 +120,7 @@ impl InputState {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct LayoutState {
     pub(crate) menu_rect: Option<Rect>,
     pub(crate) body_rect: Option<Rect>,
@@ -129,6 +129,17 @@ pub struct LayoutState {
     pub(crate) back_rect: Option<Rect>,
     pub(crate) dialog_rect: Option<Rect>,
     pub(crate) mouse_pos: (u16, u16),
+}
+
+impl LayoutState {
+    pub(crate) fn clear_interaction_regions(&mut self) {
+        let mouse_pos = self.mouse_pos;
+        *self = Self { mouse_pos, ..Self::default() };
+    }
+
+    pub(crate) fn mouse_interactions_enabled(&self) -> bool {
+        self.body_rect.is_some()
+    }
 }
 
 #[derive(Debug)]
@@ -183,15 +194,7 @@ impl TuiApp {
             input: None,
             daemon_running,
             daemon_installed: daemon::DaemonManager::create().is_installed(),
-            layout: LayoutState {
-                menu_rect: None,
-                body_rect: None,
-                log_rect: None,
-                clear_rect: None,
-                back_rect: None,
-                dialog_rect: None,
-                mouse_pos: (0, 0),
-            },
+            layout: LayoutState::default(),
             tx,
             rx,
             command_handle: None,
@@ -288,6 +291,7 @@ impl TuiApp {
                 self.handle_mouse(mouse);
                 true
             }
+            Some(Ok(Event::Resize(_, _))) => true,
             _ => false,
         }
     }
@@ -514,4 +518,36 @@ fn spawn_daemon_poller(
             }
         }
     });
+}
+
+#[cfg(test)]
+fn test_app() -> TuiApp {
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    let (draw_tx, _) = broadcast::channel(1);
+    let frame_requester = FrameRequester::new(draw_tx.clone());
+    let ctx = AppContext {
+        config_file: std::path::PathBuf::new(),
+        config_root: std::path::PathBuf::new(),
+        mirror: false,
+        daemon: false,
+        spotify_data_dir: std::path::PathBuf::new(),
+        spotify_exec: std::path::PathBuf::new(),
+        offline_bnk_dir: std::path::PathBuf::new(),
+        block_spotify_updates: None,
+    };
+
+    TuiApp::new(ctx, tx, rx, frame_requester, draw_tx)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn resize_events_request_redraw() {
+        let mut app = test_app();
+
+        assert!(app.handle_terminal_event(Some(Ok(Event::Resize(80, 24)))));
+        assert!(!app.handle_terminal_event(Some(Ok(Event::FocusGained))));
+    }
 }

--- a/rust/crates/tui/src/render.rs
+++ b/rust/crates/tui/src/render.rs
@@ -1,5 +1,5 @@
 use ratatui::Frame;
-use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::layout::{Alignment, Constraint, Layout, Rect};
 use ratatui::style::Style;
 use ratatui::widgets::Paragraph;
 use spicetify::fl;
@@ -10,17 +10,55 @@ use crate::components::{confirm_quit, details_pane, footer};
 use crate::theme::TEXT_MUTED;
 
 pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut TuiApp) {
-    let content = content_area(frame.area());
+    let term_area = frame.area();
 
-    let [brand, _, body, log, _, footer_area] = Layout::vertical([
-        Constraint::Length(1),
-        Constraint::Length(1),
-        Constraint::Length(8),
-        Constraint::Min(12),
-        Constraint::Length(1),
-        Constraint::Length(3),
-    ])
-    .areas::<6>(content);
+    if term_area.width < 45 || term_area.height < 15 {
+        let text = format!(
+            "Terminal too small\nMinimum: 45x15 | Current: {}x{}",
+            term_area.width, term_area.height
+        );
+        let warning = Paragraph::new(text)
+            .alignment(Alignment::Center)
+            .style(Style::default().fg(TEXT_MUTED));
+
+        let vertical =
+            Layout::vertical([Constraint::Fill(1), Constraint::Length(2), Constraint::Fill(1)])
+                .split(term_area);
+
+        frame.render_widget(warning, vertical[1]);
+        return;
+    }
+
+    let content = content_area(term_area);
+
+    let (brand, body, log, footer_area) = if content.width >= 100 {
+        let [brand, _, main_area, _, footer_area] = Layout::vertical([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Min(6),
+            Constraint::Length(1),
+            Constraint::Length(3),
+        ])
+        .areas::<5>(content);
+
+        let [body, log] =
+            Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
+                .areas::<2>(main_area);
+
+        (brand, body, log, footer_area)
+    } else {
+        let [brand, _, body, log, _, footer_area] = Layout::vertical([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(8),
+            Constraint::Min(4),
+            Constraint::Length(1),
+            Constraint::Length(3),
+        ])
+        .areas::<6>(content);
+
+        (brand, body, log, footer_area)
+    };
 
     app.layout.log_rect = Some(log);
     app.header.render(frame, brand);
@@ -72,7 +110,14 @@ pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut TuiApp) {
     details_pane::render(frame, pane.right_area, &details_ctx);
 
     app.log_viewer.render(frame, log, "log");
-    let clear_rect = Rect { x: log.x + log.width.saturating_sub(5), y: log.y, width: 5, height: 1 };
+
+    let button_w = log.width.min(5);
+    let clear_rect = Rect {
+        x: log.x + log.width.saturating_sub(button_w),
+        y: log.y,
+        width: button_w,
+        height: 1,
+    };
     app.layout.clear_rect = Some(clear_rect);
     button::draw_button(
         frame,
@@ -103,13 +148,20 @@ pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut TuiApp) {
 }
 
 fn content_area(term: Rect) -> Rect {
-    let content_width = term.width.saturating_sub(3).min(78);
-    let h_margin = (term.width.saturating_sub(content_width)) / 2;
+    let h_margin = if term.width >= 120 {
+        2
+    } else if term.width >= 80 {
+        1
+    } else {
+        0
+    };
+    let v_margin = u16::from(term.height >= 24);
+
     Rect {
         x: term.x.saturating_add(h_margin),
-        y: term.y.saturating_add(4),
-        width: content_width.max(1),
-        height: term.height.saturating_sub(8).max(1),
+        y: term.y.saturating_add(v_margin),
+        width: term.width.saturating_sub(h_margin * 2).max(1),
+        height: term.height.saturating_sub(v_margin * 2).max(1),
     }
 }
 
@@ -123,7 +175,7 @@ fn draw_version(frame: &mut Frame<'_>) {
         Rect {
             x: area.width.saturating_sub(w).saturating_sub(1),
             y: area.height.saturating_sub(1),
-            width: w,
+            width: w.min(area.width),
             height: 1,
         },
     );

--- a/rust/crates/tui/src/render.rs
+++ b/rust/crates/tui/src/render.rs
@@ -1,22 +1,24 @@
 use ratatui::Frame;
-use ratatui::layout::{Alignment, Constraint, Layout, Rect};
+use ratatui::layout::{Alignment, Constraint, Layout, Margin, Rect};
 use ratatui::style::Style;
 use ratatui::widgets::Paragraph;
 use spicetify::fl;
 
-use crate::app::{Page, TuiApp};
+use crate::app::{LayoutState, Page, TuiApp};
 use crate::components::primitives::{button, split_pane};
 use crate::components::{confirm_quit, details_pane, footer};
 use crate::theme::TEXT_MUTED;
 
-pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut TuiApp) {
-    let term_area = frame.area();
+const MIN_TERMINAL_WIDTH: u16 = 45;
+const MIN_TERMINAL_HEIGHT: u16 = 15;
+const WIDE_CONTENT_WIDTH: u16 = 100;
 
-    if draw_small_term_warning(frame, term_area) {
+pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut TuiApp) {
+    if draw_small_term_warning(frame, &mut app.layout) {
         return;
     }
 
-    let content = content_area(term_area);
+    let content = content_area(frame.area());
     let (brand, body, log, footer_area) = compute_layout(content);
 
     app.layout.log_rect = Some(log);
@@ -75,13 +77,18 @@ pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut TuiApp) {
     }
 }
 
-fn draw_small_term_warning(frame: &mut Frame<'_>, area: Rect) -> bool {
-    if area.width >= 45 && area.height >= 15 {
+fn draw_small_term_warning(frame: &mut Frame<'_>, layout: &mut LayoutState) -> bool {
+    let area = frame.area();
+    if area.width >= MIN_TERMINAL_WIDTH && area.height >= MIN_TERMINAL_HEIGHT {
         return false;
     }
 
-    let text =
-        format!("Terminal too small\nMinimum: 45x15 | Current: {}x{}", area.width, area.height);
+    layout.clear_interaction_regions();
+
+    let text = format!(
+        "Terminal too small\nMinimum: {MIN_TERMINAL_WIDTH}x{MIN_TERMINAL_HEIGHT} | Current: {}x{}",
+        area.width, area.height
+    );
     let warning =
         Paragraph::new(text).alignment(Alignment::Center).style(Style::default().fg(TEXT_MUTED));
 
@@ -94,7 +101,7 @@ fn draw_small_term_warning(frame: &mut Frame<'_>, area: Rect) -> bool {
 }
 
 fn compute_layout(content: Rect) -> (Rect, Rect, Rect, Rect) {
-    if content.width >= 100 {
+    if content.width >= WIDE_CONTENT_WIDTH {
         let [brand, _, main_area, _, footer_area] = Layout::vertical([
             Constraint::Length(1),
             Constraint::Length(1),
@@ -172,12 +179,7 @@ fn content_area(term: Rect) -> Rect {
     let h_margin = if term.width >= 120 { 2 } else { u16::from(term.width >= 80) };
     let v_margin = u16::from(term.height >= 24);
 
-    Rect {
-        x: term.x.saturating_add(h_margin),
-        y: term.y.saturating_add(v_margin),
-        width: term.width.saturating_sub(h_margin * 2).max(1),
-        height: term.height.saturating_sub(v_margin * 2).max(1),
-    }
+    term.inner(Margin { horizontal: h_margin, vertical: v_margin })
 }
 
 fn draw_version(frame: &mut Frame<'_>) {
@@ -194,4 +196,156 @@ fn draw_version(frame: &mut Frame<'_>) {
             height: 1,
         },
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error;
+
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use ratatui::buffer::Cell;
+
+    use super::*;
+    use crate::LayoutState;
+
+    fn populated_layout() -> LayoutState {
+        let rect = Some(Rect::new(1, 1, 8, 4));
+        LayoutState {
+            menu_rect: rect,
+            body_rect: rect,
+            log_rect: rect,
+            clear_rect: rect,
+            back_rect: rect,
+            dialog_rect: rect,
+            mouse_pos: (7, 9),
+        }
+    }
+
+    #[test]
+    fn small_terminals_show_warning_and_clear_interaction_regions() -> Result<(), Box<dyn Error>> {
+        for (width, height) in [(44, 15), (45, 14), (80, 14)] {
+            let mut terminal = Terminal::new(TestBackend::new(width, height))?;
+            let mut layout = populated_layout();
+
+            let _completed_frame = terminal.draw(|frame| {
+                assert!(draw_small_term_warning(frame, &mut layout));
+            })?;
+
+            assert!(layout.menu_rect.is_none());
+            assert!(layout.body_rect.is_none());
+            assert!(layout.log_rect.is_none());
+            assert!(layout.clear_rect.is_none());
+            assert!(layout.back_rect.is_none());
+            assert!(layout.dialog_rect.is_none());
+            assert_eq!(layout.mouse_pos, (7, 9));
+            assert!(!layout.mouse_interactions_enabled());
+
+            let screen =
+                terminal.backend().buffer().content().iter().map(Cell::symbol).collect::<String>();
+            assert!(screen.contains("Terminal too small"));
+            assert!(screen.contains(&format!(
+                "Minimum: {MIN_TERMINAL_WIDTH}x{MIN_TERMINAL_HEIGHT} | Current: {width}x{height}"
+            )));
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn minimum_terminal_size_does_not_show_warning() -> Result<(), Box<dyn Error>> {
+        let mut terminal = Terminal::new(TestBackend::new(45, 15))?;
+        let mut layout = populated_layout();
+
+        let _completed_frame = terminal.draw(|frame| {
+            assert!(!draw_small_term_warning(frame, &mut layout));
+        })?;
+
+        assert_eq!(layout.menu_rect, Some(Rect::new(1, 1, 8, 4)));
+        assert_eq!(layout.mouse_pos, (7, 9));
+        assert!(layout.mouse_interactions_enabled());
+
+        Ok(())
+    }
+
+    #[test]
+    fn screen_sizes_select_the_expected_layout() {
+        let cases = [
+            (
+                45,
+                15,
+                Rect::new(0, 0, 45, 15),
+                Rect::new(0, 2, 45, 5),
+                Rect::new(0, 7, 45, 4),
+                Rect::new(0, 12, 45, 3),
+            ),
+            (
+                79,
+                23,
+                Rect::new(0, 0, 79, 23),
+                Rect::new(0, 2, 79, 8),
+                Rect::new(0, 10, 79, 9),
+                Rect::new(0, 20, 79, 3),
+            ),
+            (
+                80,
+                24,
+                Rect::new(1, 1, 78, 22),
+                Rect::new(1, 3, 78, 8),
+                Rect::new(1, 11, 78, 8),
+                Rect::new(1, 20, 78, 3),
+            ),
+            (
+                101,
+                24,
+                Rect::new(1, 1, 99, 22),
+                Rect::new(1, 3, 99, 8),
+                Rect::new(1, 11, 99, 8),
+                Rect::new(1, 20, 99, 3),
+            ),
+            (
+                102,
+                24,
+                Rect::new(1, 1, 100, 22),
+                Rect::new(1, 3, 50, 16),
+                Rect::new(51, 3, 50, 16),
+                Rect::new(1, 20, 100, 3),
+            ),
+            (
+                119,
+                23,
+                Rect::new(1, 0, 117, 23),
+                Rect::new(1, 2, 59, 17),
+                Rect::new(60, 2, 58, 17),
+                Rect::new(1, 20, 117, 3),
+            ),
+            (
+                120,
+                24,
+                Rect::new(2, 1, 116, 22),
+                Rect::new(2, 3, 58, 16),
+                Rect::new(60, 3, 58, 16),
+                Rect::new(2, 20, 116, 3),
+            ),
+            (
+                160,
+                40,
+                Rect::new(2, 1, 156, 38),
+                Rect::new(2, 3, 78, 32),
+                Rect::new(80, 3, 78, 32),
+                Rect::new(2, 36, 156, 3),
+            ),
+        ];
+
+        for (width, height, expected_content, expected_body, expected_log, expected_footer) in cases
+        {
+            let content = content_area(Rect::new(0, 0, width, height));
+            let (_, body, log, footer) = compute_layout(content);
+
+            assert_eq!(content, expected_content);
+            assert_eq!(body, expected_body, "unexpected body at {width}x{height}");
+            assert_eq!(log, expected_log, "unexpected log at {width}x{height}");
+            assert_eq!(footer, expected_footer, "unexpected footer at {width}x{height}");
+        }
+    }
 }

--- a/rust/crates/tui/src/render.rs
+++ b/rust/crates/tui/src/render.rs
@@ -12,75 +12,18 @@ use crate::theme::TEXT_MUTED;
 pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut TuiApp) {
     let term_area = frame.area();
 
-    if term_area.width < 45 || term_area.height < 15 {
-        let text = format!(
-            "Terminal too small\nMinimum: 45x15 | Current: {}x{}",
-            term_area.width, term_area.height
-        );
-        let warning = Paragraph::new(text)
-            .alignment(Alignment::Center)
-            .style(Style::default().fg(TEXT_MUTED));
-
-        let vertical =
-            Layout::vertical([Constraint::Fill(1), Constraint::Length(2), Constraint::Fill(1)])
-                .split(term_area);
-
-        frame.render_widget(warning, vertical[1]);
+    if draw_small_term_warning(frame, term_area) {
         return;
     }
 
     let content = content_area(term_area);
-
-    let (brand, body, log, footer_area) = if content.width >= 100 {
-        let [brand, _, main_area, _, footer_area] = Layout::vertical([
-            Constraint::Length(1),
-            Constraint::Length(1),
-            Constraint::Min(6),
-            Constraint::Length(1),
-            Constraint::Length(3),
-        ])
-        .areas::<5>(content);
-
-        let [body, log] =
-            Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
-                .areas::<2>(main_area);
-
-        (brand, body, log, footer_area)
-    } else {
-        let [brand, _, body, log, _, footer_area] = Layout::vertical([
-            Constraint::Length(1),
-            Constraint::Length(1),
-            Constraint::Length(8),
-            Constraint::Min(4),
-            Constraint::Length(1),
-            Constraint::Length(3),
-        ])
-        .areas::<6>(content);
-
-        (brand, body, log, footer_area)
-    };
+    let (brand, body, log, footer_area) = compute_layout(content);
 
     app.layout.log_rect = Some(log);
     app.header.render(frame, brand);
 
-    let in_category = matches!(app.menu.page, Page::Category(_));
-    let mut menu_title = match app.menu.page {
-        Page::Main => "categories".to_string(),
-        Page::Category(i) => {
-            let data = crate::components::menu_list::CATEGORIES;
-            data.get(i).map_or_else(|| fl!("tui-actions"), |c| c.id.label().to_lowercase())
-        }
-    };
-    if in_category {
-        menu_title = format!("← {menu_title}");
-    }
-    let details_title = if app.input.is_some() {
-        "input".to_string()
-    } else if app.cmd.current.is_some() {
-        fl!("tui-running")
-    } else {
-        "details".to_string()
-    };
+    let (menu_title, in_category) = get_menu_title(app.menu.page);
+    let details_title = get_details_title(app);
 
     let pane = split_pane::draw(
         frame,
@@ -111,22 +54,7 @@ pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut TuiApp) {
 
     app.log_viewer.render(frame, log, "log");
 
-    let button_w = log.width.min(5);
-    let clear_rect = Rect {
-        x: log.x + log.width.saturating_sub(button_w),
-        y: log.y,
-        width: button_w,
-        height: 1,
-    };
-    app.layout.clear_rect = Some(clear_rect);
-    button::draw_button(
-        frame,
-        "clear",
-        clear_rect,
-        app.layout.mouse_pos,
-        app.menu.hover.is_mouse_active(),
-        false,
-    );
+    draw_clear_button(frame, app, log);
 
     let footer_ctx = footer::FooterCtx {
         page: app.menu.page,
@@ -147,14 +75,101 @@ pub(crate) fn draw(frame: &mut Frame<'_>, app: &mut TuiApp) {
     }
 }
 
-fn content_area(term: Rect) -> Rect {
-    let h_margin = if term.width >= 120 {
-        2
-    } else if term.width >= 80 {
-        1
+fn draw_small_term_warning(frame: &mut Frame<'_>, area: Rect) -> bool {
+    if area.width >= 45 && area.height >= 15 {
+        return false;
+    }
+
+    let text =
+        format!("Terminal too small\nMinimum: 45x15 | Current: {}x{}", area.width, area.height);
+    let warning =
+        Paragraph::new(text).alignment(Alignment::Center).style(Style::default().fg(TEXT_MUTED));
+
+    let [_, warning_area, _] =
+        Layout::vertical([Constraint::Fill(1), Constraint::Length(2), Constraint::Fill(1)])
+            .areas::<3>(area);
+
+    frame.render_widget(warning, warning_area);
+    true
+}
+
+fn compute_layout(content: Rect) -> (Rect, Rect, Rect, Rect) {
+    if content.width >= 100 {
+        let [brand, _, main_area, _, footer_area] = Layout::vertical([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Min(6),
+            Constraint::Length(1),
+            Constraint::Length(3),
+        ])
+        .areas::<5>(content);
+
+        let [body, log] =
+            Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)])
+                .areas::<2>(main_area);
+
+        (brand, body, log, footer_area)
     } else {
-        0
+        let [brand, _, body, log, _, footer_area] = Layout::vertical([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(8),
+            Constraint::Min(4),
+            Constraint::Length(1),
+            Constraint::Length(3),
+        ])
+        .areas::<6>(content);
+
+        (brand, body, log, footer_area)
+    }
+}
+
+fn get_menu_title(page: Page) -> (String, bool) {
+    let in_category = matches!(page, Page::Category(_));
+    let mut menu_title = match page {
+        Page::Main => "categories".to_string(),
+        Page::Category(i) => {
+            let data = crate::components::menu_list::CATEGORIES;
+            data.get(i).map_or_else(|| fl!("tui-actions"), |c| c.id.label().to_lowercase())
+        }
     };
+    if in_category {
+        menu_title = format!("← {menu_title}");
+    }
+    (menu_title, in_category)
+}
+
+fn get_details_title(app: &TuiApp) -> String {
+    if app.input.is_some() {
+        "input".to_string()
+    } else if app.cmd.current.is_some() {
+        fl!("tui-running")
+    } else {
+        "details".to_string()
+    }
+}
+
+fn draw_clear_button(frame: &mut Frame<'_>, app: &mut TuiApp, log: Rect) {
+    let button_w = log.width.min(5);
+    let clear_rect = Rect {
+        x: log.x + log.width.saturating_sub(button_w),
+        y: log.y,
+        width: button_w,
+        height: 1,
+    };
+    app.layout.clear_rect = Some(clear_rect);
+    button::draw_button(
+        frame,
+        "clear",
+        clear_rect,
+        app.layout.mouse_pos,
+        app.menu.hover.is_mouse_active(),
+        false,
+    );
+}
+
+fn content_area(term: Rect) -> Rect {
+    let h_margin = if term.width >= 120 { 2 } else { u16::from(term.width >= 80) };
     let v_margin = u16::from(term.height >= 24);
 
     Rect {


### PR DESCRIPTION
Makes the tui responsive
shows 'Terminal too small' when below 45 columns or 15 rows.

<img width="1920" height="1200" alt="2026-09-01_00-44-18" src="https://github.com/user-attachments/assets/f3faafb9-198f-4fd0-a71f-a4f4a1d19571" />
