### PR TITLE
fix(wrapper): make PopupModal styling self-contained

### DIFF
--- a/src/jsHelper/spicetifyWrapper/popup.js
+++ b/src/jsHelper/spicetifyWrapper/popup.js
@@ -1,8 +1,5 @@
-let stylesInjected = false;
-
 function injectStyles() {
-  if (stylesInjected) return;
-  stylesInjected = true;
+  if (document.querySelector("style.spicetify-popup-modal")) return;
 
   const style = document.createElement("style");
   style.className = "spicetify-popup-modal";

--- a/src/jsHelper/spicetifyWrapper/popup.js
+++ b/src/jsHelper/spicetifyWrapper/popup.js
@@ -1,3 +1,30 @@
+let stylesInjected = false;
+
+// Spotify removed the Track Credits modal component its markup was borrowed from,
+// so the classes below no longer carry any styling from Spotify's stylesheets.
+// They are kept on the elements for theme compatibility, while the `spicetify-popup-*`
+// classes own the layout. Rules are wrapped in `:where()` so they contribute no
+// specificity -- themes and extensions override them without needing `!important`.
+function injectStyles() {
+  if (stylesInjected || document.querySelector("style.spicetify-popup-modal")) return;
+  stylesInjected = true;
+
+  const style = document.createElement("style");
+  style.className = "spicetify-popup-modal";
+  style.textContent = `
+generic-modal :where(.spicetify-popup) { display: flex; max-height: calc(100vh - 64px); border-radius: 8px; overflow: hidden; }
+generic-modal :where(.spicetify-popup-container) { display: flex; flex-direction: column; width: 524px; max-width: 100%; min-height: 0; border-radius: 8px; color: var(--spice-text, var(--text-base, #fff)); background-color: var(--spice-player, var(--background-elevated-base, #121212)); }
+generic-modal :where(.spicetify-popup-container-large) { width: 664px; }
+generic-modal :where(.spicetify-popup-header) { display: flex; flex: 0 0 auto; align-items: center; justify-content: space-between; gap: 16px; padding: 24px; }
+generic-modal :where(.spicetify-popup-title) { margin: 0; font-size: 1.5rem; font-weight: 700; line-height: 1.3; }
+generic-modal :where(.spicetify-popup-closeBtn) { display: flex; flex: 0 0 auto; align-items: center; justify-content: center; width: 32px; height: 32px; padding: 0; margin-block-start: -8px; margin-inline-end: -8px; border: 0; border-radius: 50%; background-color: transparent; color: var(--spice-subtext, var(--text-subdued, #b3b3b3)); cursor: pointer; }
+generic-modal :where(.spicetify-popup-closeBtn:hover) { color: var(--spice-text, var(--text-base, #fff)); }
+generic-modal :where(.spicetify-popup-closeBtn:focus-visible) { outline: 2px solid currentColor; outline-offset: 2px; }
+generic-modal :where(.spicetify-popup-content) { flex: 1 1 auto; min-height: 0; overflow-y: auto; padding: 0 24px 24px; }
+`;
+  document.head.append(style);
+}
+
 class _HTMLGenericModal extends HTMLElement {
   hide() {
     Spicetify.ReactDOM.unmountComponentAtNode(this.querySelector("main"));
@@ -5,15 +32,21 @@ class _HTMLGenericModal extends HTMLElement {
   }
 
   display({ title, content, isLarge = false }) {
+    injectStyles();
+
+    const containerClass = isLarge
+      ? "spicetify-popup-container spicetify-popup-container-large main-embedWidgetGenerator-container"
+      : "spicetify-popup-container main-trackCreditsModal-container";
+
     this.innerHTML = `
 <div class="GenericModal__overlay" style="z-index: 100;">
-	<div class="GenericModal" tabindex="-1" role="dialog" aria-label="${title}" aria-modal="true">
-		<div class="${isLarge ? "main-embedWidgetGenerator-container" : "main-trackCreditsModal-container"}">
-			<div class="main-trackCreditsModal-header">
-				<h1 class="main-type-alto" as="h1">${title}</h1>
-				<button aria-label="Close" class="main-trackCreditsModal-closeBtn"><svg width="18" height="18" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><title>Close</title><path d="M31.098 29.794L16.955 15.65 31.097 1.51 29.683.093 15.54 14.237 1.4.094-.016 1.508 14.126 15.65-.016 29.795l1.414 1.414L15.54 17.065l14.144 14.143" fill="currentColor" fill-rule="evenodd"></path></svg></button>
+	<div class="GenericModal spicetify-popup" tabindex="-1" role="dialog" aria-label="${title}" aria-modal="true">
+		<div class="${containerClass}">
+			<div class="spicetify-popup-header main-trackCreditsModal-header">
+				<h1 class="spicetify-popup-title main-type-alto" as="h1">${title}</h1>
+				<button aria-label="Close" class="spicetify-popup-closeBtn main-trackCreditsModal-closeBtn"><svg width="18" height="18" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><title>Close</title><path d="M31.098 29.794L16.955 15.65 31.097 1.51 29.683.093 15.54 14.237 1.4.094-.016 1.508 14.126 15.65-.016 29.795l1.414 1.414L15.54 17.065l14.144 14.143" fill="currentColor" fill-rule="evenodd"></path></svg></button>
 			</div>
-			<div class="main-trackCreditsModal-mainSection">
+			<div class="spicetify-popup-content main-trackCreditsModal-mainSection">
 				<main class="main-trackCreditsModal-originalCredits"></main>
 			</div>
 		</div>

--- a/src/jsHelper/spicetifyWrapper/popup.js
+++ b/src/jsHelper/spicetifyWrapper/popup.js
@@ -1,12 +1,7 @@
 let stylesInjected = false;
 
-// Spotify removed the Track Credits modal component its markup was borrowed from,
-// so the classes below no longer carry any styling from Spotify's stylesheets.
-// They are kept on the elements for theme compatibility, while the `spicetify-popup-*`
-// classes own the layout. Rules are wrapped in `:where()` so they contribute no
-// specificity -- themes and extensions override them without needing `!important`.
 function injectStyles() {
-  if (stylesInjected || document.querySelector("style.spicetify-popup-modal")) return;
+  if (stylesInjected) return;
   stylesInjected = true;
 
   const style = document.createElement("style");


### PR DESCRIPTION
### Problem

`PopupModal` builds its markup from Spotify's old Track Credits modal. Spotify has since deleted that component, so most of the classes in the template carry no styling at all. Auditing every stylesheet in `xpui/` on **1.2.98.301**, only two of seven survive:

| Class | Styled on 1.2.98? |
|---|---|
| `.GenericModal__overlay` | ✅ |
| `.main-embedWidgetGenerator-container` | ✅ |
| `.GenericModal` | ❌ |
| `.main-trackCreditsModal-container` | ❌ |
| `.main-trackCreditsModal-header` | ❌ |
| `.main-trackCreditsModal-closeBtn` | ❌ |
| `.main-trackCreditsModal-mainSection` | ❌ |
| `.main-type-alto` | ❌ |

Every Spicetify modal — ours and every extension's — therefore renders with an unstyled shell: no padding, the close button falling into normal flow **below** the title wearing default `<button>` chrome, an oversized default `h1`, and no scroll container, so tall content runs off the bottom of the window with no way to reach it. `isLarge: false` modals fare worst; their container has no styling left whatsoever.

This is a repeat: #3090 ("modals broken") was the same class of breakage in 2024.

### Why not css-map

This was my first instinct, and it doesn't work:

- The map already carries **41** `main-trackCreditsModal-*` entries. They're inert — the component was *removed*, not renamed, so there's no hash left to rewrite. `main-type-alto` has zero entries.
- The map has `zogFp9G1AEqb8AKOd5B0 → GenericModal`, but 1.2.98's modal box is `w1gLwZlc_sWpQ3CJ`. Adding that hash looks like a one-line fix — except `.w1gLwZlc_sWpQ3CJ` carries exactly one declaration, `-webkit-app-region: no-drag`. It's the bare react-modal base class.

Modern Spotify styles each dialog's *own* container rather than a shared modal box; the only thing dialogs still share is `__overlay`. There is nothing generic left to map onto.

Borrowing another live dialog's classes (`main-playlistEditDetailsModal-*`) would work today, but that's the same bet that just lost — Track Credits was live once too. It resets the clock instead of stopping it.

### Fix

Own the styling, as we already do for `ScrollableContainer`. Layout moves onto `spicetify-popup-*` classes backed by an injected stylesheet, following the existing `custom-apps.js` / `scrollable-container.js` pattern.

Two properties worth calling out:

- **Themes keep working.** The legacy class names stay on the elements, and every rule is wrapped in `:where()` so it contributes no specificity. A theme's plain `.main-trackCreditsModal-header { … }` still wins, with no `!important` needed.
- **`isLarge: true` still defers to Spotify.** It keeps `main-embedWidgetGenerator-container`, which Spotify does still style; our matching rule sits underneath as a fallback for when that one goes too.

### Verification

Against Spotify **1.2.98.301** over CDP, A/B against a wrapper built from the same tree *without* this change, with Marketplace's stylesheet disabled so only the wrapper is under test:

| | Control | With fix |
|---|---|---|
| header `display` | `block` | `flex` |
| header `padding` | `0px` | `24px` |
| title / close `y` | `90` / `134` (stacked) | `101` / `96` (same row) |
| close button | `2px` border, 28×33 | `0px` border, 32×32 |
| `h1` font-size | `32px` | `24px` |
| main `overflow-y` | `visible` | `auto` |
| border-radius | `0px` | `8px` |

Also confirmed:
- a simulated theme rule (`padding: 4px`, `border-radius: 0`) overrides the defaults without `!important`
- `isLarge: false` is now styled — 524px, background, 8px radius, flex column
- `isLarge: true` still measures Spotify's 664px container

`pnpm lint` and `pnpm fmt --check` clean. Source-only change; `jsHelper/spicetifyWrapper.js` is gitignored and built at release time.

`v3-beta` carries an identical `popup.js`, so this cherry-picks cleanly if wanted there.

### Related

Marketplace has a stopgap for its own modals in spicetify/marketplace#1235. That only helps users who have Marketplace installed; this fixes it for everyone, and that one can be dropped once this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ds6ryy1Edpg9MS5VcB6Dmc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved popup modal layout and visual consistency.
  * Added clearer styling for overlays, dialogs, headers, titles, close controls, and content areas.
  * Applied popup styling when a modal is first displayed.
  * Preserved compatibility with Spotify’s existing themes and styling.
  * Improved handling of large and standard popup layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->