### PR TITLE
chore(vscode): use oxc formatter instead of biome

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-	"recommendations": ["timonwong.shellcheck", "biomejs.biome", "golang.go", "ms-vscode.powershell"]
+	"recommendations": ["timonwong.shellcheck", "oxc.oxc-vscode", "golang.go", "ms-vscode.powershell"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,16 @@
 	"[powershell]": {
 		"editor.defaultFormatter": "ms-vscode.powershell"
 	},
-	"[javascript][typescript][json]": {
+	"[javascript]": {
+		"editor.defaultFormatter": "oxc.oxc-vscode"
+	},
+	"[typescript]": {
+		"editor.defaultFormatter": "oxc.oxc-vscode"
+	},
+	"[json]": {
+		"editor.defaultFormatter": "oxc.oxc-vscode"
+	},
+	"[jsonc]": {
 		"editor.defaultFormatter": "oxc.oxc-vscode"
 	}
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,6 @@
 		"editor.defaultFormatter": "ms-vscode.powershell"
 	},
 	"[javascript][typescript][json]": {
-		"editor.defaultFormatter": "biomejs.biome"
+		"editor.defaultFormatter": "oxc.oxc-vscode"
 	}
 }


### PR DESCRIPTION
The project's JS tooling moved to oxfmt/oxlint — `package.json` runs `oxfmt` and `oxlint`, with config in `.oxfmtrc.json` / `.oxlintrc.json` — but `.vscode/` still points at `biomejs.biome`. This updates it to match.

`oxc.oxc-vscode` wraps the same `oxfmt` and `oxlint` binaries already in `devDependencies`, so the editor and CI use one toolchain.

### Changes

- `extensions.json` — `biomejs.biome` → `oxc.oxc-vscode` in `recommendations`
- `settings.json` — same swap, **and** the combined `[javascript][typescript][json]` key split into single-language blocks

### Why the key had to be split

Per the [VS Code settings docs](https://code.visualstudio.com/docs/configure/settings): *"If a setting is configured in both a single-language block and a multiple-language block, the single-language value takes precedence. This precedence is applied before the normal setting scope precedence rules"* — and explicitly, *"a `[typescript][javascript]` workspace setting will not override a `[javascript]` user setting."*

So the combined key here was losing to any contributor's own `[javascript]` block in their user settings, regardless of workspace-over-user scoping. Anyone with a personal default formatter for JavaScript had it silently win over this file, which is how a repo configured for `printWidth: 150` and double quotes ends up reformatted to 80 columns and single quotes on save. Splitting into single-language blocks puts both sides at the same specificity, so the normal workspace-beats-user rule applies.

Go and PowerShell entries are untouched. `[jsonc]` added alongside `[json]` since the extension registers for it and the repo has jsonc-style config files.

Config only — nothing in the build or CI path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ds6ryy1Edpg9MS5VcB6Dmc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated recommended VS Code extensions to use Oxc instead of Biome.
  * Updated the default formatter for JavaScript, TypeScript, and JSON files to Oxc.
  * Added Oxc formatting support for JSONC files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->